### PR TITLE
feat(p3.2): pilot scope S3 connector config — .env.example + docs/connector-config.md

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,30 @@
+# agentopia-rag-platform — Pipeline environment variables
+# Copy to .env for local development. All vars are required unless marked optional.
+# In Kubernetes, these are set via K8s Secrets (never hardcoded in manifests).
+
+# ── Qdrant ───────────────────────────────────────────────────────────────────
+QDRANT_URL=http://qdrant:6333
+# Collection name: kb-{sha256(scope)[:16]}
+# Pilot scope (joblogic-kb/api-docs): kb-1f28b6baebe4f76d
+QDRANT_COLLECTION=kb-1f28b6baebe4f76d
+
+# ── S3 source ────────────────────────────────────────────────────────────────
+S3_BUCKET_NAME=agentopia-rag-ingest
+# Prefix convention: scopes/{client_id}/{scope_name}/
+# Pilot scope prefix: scopes/joblogic-kb/api-docs/
+S3_PREFIX=scopes/joblogic-kb/api-docs/
+S3_REGION=ap-southeast-1
+S3_ACCESS_KEY=           # from K8s Secret in production
+S3_SECRET_ACCESS_KEY=    # from K8s Secret in production
+
+# ── Embedding ────────────────────────────────────────────────────────────────
+# OpenAI-compatible endpoint. Set to OpenRouter or local model as needed.
+EMBEDDING_BASE_URL=https://api.openai.com/v1
+EMBEDDING_API_KEY=       # from K8s Secret in production
+EMBEDDING_MODEL=text-embedding-3-small
+
+# ── Pathway runtime ──────────────────────────────────────────────────────────
+# Poll interval: S3 is re-scanned every N seconds for new/changed/deleted objects
+PATHWAY_POLL_INTERVAL_SECS=30
+# Persistence state directory: mount a PVC at this path in K8s
+PATHWAY_STATE_DIR=/var/pathway/state

--- a/docs/connector-config.md
+++ b/docs/connector-config.md
@@ -1,0 +1,62 @@
+# Pathway Connector Configuration — Pilot Scope
+
+> Phase: P3.2  
+> Pilot scope: `joblogic-kb/api-docs`
+
+---
+
+## S3 Connector Config (Pilot)
+
+| Parameter | Value |
+|---|---|
+| `S3_BUCKET_NAME` | `agentopia-rag-ingest` |
+| `S3_PREFIX` | `scopes/joblogic-kb/api-docs/` |
+| `S3_REGION` | `ap-southeast-1` |
+| `PATHWAY_POLL_INTERVAL_SECS` | `30` |
+| `QDRANT_COLLECTION` | `kb-1f28b6baebe4f76d` |
+| `EMBEDDING_MODEL` | `text-embedding-3-small` |
+
+QDRANT_COLLECTION is derived as `kb-{sha256("joblogic-kb/api-docs")[:16]}` per the collection naming convention in `migration-plan.md §6`.
+
+## S3 Prefix Convention
+
+```
+s3://{S3_BUCKET_NAME}/scopes/{client_id}/{scope_name}/{filename}
+```
+
+All documents for a scope are stored under `scopes/{client_id}/{scope_name}/`. Pathway monitors this prefix for additions, updates, and deletions. Documents written to the staging bucket by the upload API or the GitHub Actions sync workflow land here.
+
+**Pilot scope path**: `s3://agentopia-rag-ingest/scopes/joblogic-kb/api-docs/`
+
+## Document Format (Pilot)
+
+Pilot scope `joblogic-kb/api-docs` contains markdown files only (`.md`). The pipeline uses `format="plaintext_by_object"` for this scope.
+
+DOCX and binary file support is tracked in ticket #25 — not part of this pilot.
+
+## Credentials (K8s Secrets)
+
+In production, these env vars are set via K8s Secrets — never hardcoded:
+
+```
+S3_ACCESS_KEY            → Secret: agentopia-rag-platform-s3
+S3_SECRET_ACCESS_KEY     → Secret: agentopia-rag-platform-s3
+EMBEDDING_API_KEY        → Secret: agentopia-rag-platform-embedding
+```
+
+See `.env.example` for the full env var list.
+
+## Pathway Persistence
+
+The state PVC must be mounted at `PATHWAY_STATE_DIR` (default `/var/pathway/state`). Without the PVC, Pathway cold-starts on every pod restart and re-indexes all documents from S3. The PVC preserves checkpoint state across restarts, allowing incremental operation.
+
+PVC provisioning is tracked in P3.1 remaining cluster work.
+
+## Single-Publisher Invariant
+
+Once `scope_ingest_mode: pathway` is set for `joblogic-kb/api-docs`:
+- `POST /api/v1/upload` on knowledge-ingest returns `409 Conflict` for this scope
+- Pathway is the sole writer to `kb-1f28b6baebe4f76d`
+- Legacy orchestrator does not run for this scope
+
+The guard is implemented in `agentopia-knowledge-ingest` upload endpoint (P3.2 cross-repo work).


### PR DESCRIPTION
## Summary

Repo-owned scope for P3.2. Commits the S3 connector config for the pilot scope.

- **`.env.example`** — all required env vars for `src/ingest/pipeline.py` with pilot scope values: `S3_PREFIX=scopes/joblogic-kb/api-docs/`, `PATHWAY_POLL_INTERVAL_SECS=30`, `QDRANT_COLLECTION=kb-1f28b6baebe4f76d`
- **`docs/connector-config.md`** — S3 prefix convention, QDRANT_COLLECTION derivation, document format assumption (markdown-only), single-publisher invariant note

## Pilot scope locked

- Scope: `joblogic-kb/api-docs`
- S3 prefix: `scopes/joblogic-kb/api-docs/`
- Collection: `kb-1f28b6baebe4f76d`
- Document format: markdown only

## Acceptance criteria

- [x] S3 connector config committed (bucket, prefix, `PATHWAY_POLL_INTERVAL_SECS=30`)

Part of #6