### PR TITLE
fix: add pdf2image to requirements (pathway.xpacks.llm transitive dep)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ qdrant-client>=1.7.0
 openai>=1.0.0
 aiohttp>=3.9.0
 python-dotenv>=1.0.0
+pdf2image>=1.16.0


### PR DESCRIPTION
## Problem

Pod crash on startup:
```
ModuleNotFoundError: No module named 'pdf2image'
```

`pathway.xpacks.llm.parsers` imports `pdf2image` unconditionally. Even though the pipeline only uses `OpenAIEmbedder`, the `pathway.xpacks.llm` package init chains through `document_store → parsers → pdf2image`.

## Fix

Add `pdf2image>=1.16.0` to `requirements.txt`. The package can be imported without the `poppler` system binary installed — it only fails on actual PDF conversion calls, which this pipeline never makes.

## Evidence

Container logs from `agentopia-rag-platform-574668b75b-mbrnp`:
```
[rag-platform] Loaded secrets from Vault
ModuleNotFoundError: No module named 'pdf2image'
  File "pathway/xpacks/llm/parsers.py", line 22, in <module>
    from pdf2image import convert_from_bytes
```