### PR TITLE
fix: replace OpenAIEmbedder with direct pw.udf to avoid xpacks.llm heavy deps

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,3 @@ qdrant-client>=1.7.0
 openai>=1.0.0
 aiohttp>=3.9.0
 python-dotenv>=1.0.0
-pdf2image>=1.16.0

--- a/src/ingest/pipeline.py
+++ b/src/ingest/pipeline.py
@@ -22,7 +22,7 @@ import hashlib
 import os
 
 import pathway as pw
-from pathway.xpacks.llm.embedders import OpenAIEmbedder
+from openai import OpenAI
 from qdrant_client import QdrantClient
 from qdrant_client.models import Distance, PointStruct, VectorParams
 
@@ -51,6 +51,15 @@ POLL_INTERVAL = int(os.environ.get("PATHWAY_POLL_INTERVAL_SECS", "30"))
 STATE_DIR = os.environ.get("PATHWAY_STATE_DIR", "/var/pathway/state")
 
 VECTOR_DIM = 1536  # text-embedding-3-small output dimension
+
+_openai_client = OpenAI(api_key=EMBEDDING_API_KEY, base_url=EMBEDDING_BASE_URL)
+
+
+@pw.udf
+def embed_text(text: str) -> list:
+    """Embed a single text chunk using the configured OpenAI-compatible endpoint."""
+    resp = _openai_client.embeddings.create(input=text, model=EMBEDDING_MODEL)
+    return resp.data[0].embedding
 
 
 # ---------------------------------------------------------------------------
@@ -144,15 +153,9 @@ def build_pipeline() -> None:
     )
 
     # -- Transform: embed each document chunk ---------------------------------
-    embedder = OpenAIEmbedder(
-        api_key=EMBEDDING_API_KEY,
-        model=EMBEDDING_MODEL,
-        api_base=EMBEDDING_BASE_URL,
-    )
-
     embedded = documents.select(
         **documents,
-        embedding=embedder(pw.this.text),
+        embedding=embed_text(pw.this.text),
     )
 
     # -- Sink: Qdrant upsert --------------------------------------------------


### PR DESCRIPTION
## Problem

Container crashes at startup due to chained missing dependencies:
1. `pathway.xpacks.llm.embedders` → triggers `pathway.xpacks.llm.__init__`
2. `__init__` imports `document_store` → which imports `parsers`
3. `parsers.py` imports `pdf2image` (line 22) and `unstructured` (line 25) — both optional system-level packages not included in `python:3.11-slim`

## Fix

Replace `OpenAIEmbedder` with a `@pw.udf` wrapping the `openai` client directly:
- Removes the entire `pathway.xpacks.llm` import chain
- Uses `openai` package (already in requirements.txt)
- Same behavior: same API, model, base URL, 1536-dim output
- No system packages or heavy optional deps required

## Evidence

Previous crashes in `agentopia-rag-platform-845b6f5c5-gkbhp`:
```
ModuleNotFoundError: No module named 'pdf2image'
ModuleNotFoundError: No module named 'unstructured'
```