### PR TITLE
fix: truncate embed input to 30k chars to avoid token limit crash

### DIFF
--- a/src/ingest/pipeline.py
+++ b/src/ingest/pipeline.py
@@ -51,13 +51,23 @@ POLL_INTERVAL = int(os.environ.get("PATHWAY_POLL_INTERVAL_SECS", "30"))
 STATE_DIR = os.environ.get("PATHWAY_STATE_DIR", "/var/pathway/state")
 
 VECTOR_DIM = 1536  # text-embedding-3-small output dimension
+# text-embedding-3-small max input: 8191 tokens (~4 chars/token).
+# Truncate to stay under limit; for production use a chunking pass.
+_MAX_EMBED_CHARS = 30_000  # ≈ 7500 tokens — safe margin for the 8191-token limit
 
 _openai_client = OpenAI(api_key=EMBEDDING_API_KEY, base_url=EMBEDDING_BASE_URL)
 
 
 @pw.udf
 def embed_text(text: str) -> list:
-    """Embed a single text chunk using the configured OpenAI-compatible endpoint."""
+    """Embed a single text chunk using the configured OpenAI-compatible endpoint.
+
+    Truncates input to _MAX_EMBED_CHARS to stay within text-embedding-3-small's
+    8191-token limit. OpenRouter returns data:[] (not an HTTP error) for over-limit
+    inputs, which the openai client surfaces as ValueError('No embedding data received').
+    """
+    if len(text) > _MAX_EMBED_CHARS:
+        text = text[:_MAX_EMBED_CHARS]
     resp = _openai_client.embeddings.create(input=text, model=EMBEDDING_MODEL)
     return resp.data[0].embedding
 


### PR DESCRIPTION
## Problem

`super-rag-debate.md` in `s3://utop-oddspark-document/architecture/` is 57,779 chars (~14,444 tokens). OpenRouter's `text-embedding-3-small` has an 8191-token limit and returns `data: []` (200 OK) for over-limit inputs. The `openai` client raises `ValueError: No embedding data received`, crashing `pw.run()`.

## Evidence

From cluster test (`super-rag-debate.md` at 57,779 chars):
```
TEXT_LEN: 57779 chars (~ 14444 tokens)
EMBED_OK: data_len= 0  ← empty data, triggers ValueError
```

From cluster test (`repo-split-notes.md` at 1039 chars):
```
TEXT_LEN: 1039 chars
EMBED_OK: data_len= 1, DIM: 1536  ← success
```

## Fix

Truncate text to 30,000 chars (~7,500 tokens) before embedding — safe margin under the 8191-token limit. Full document chunking is a follow-up task; this unblocks end-to-end activation for the `architecture/` prefix.