### PR TITLE
eval(p3.3): chunk quality spot-check — live utop/oddspark scope (#7)

### DIFF
--- a/src/eval/results/p3.3-chunk-quality-spot-check.md
+++ b/src/eval/results/p3.3-chunk-quality-spot-check.md
@@ -1,0 +1,251 @@
+# P3.3 Chunk Quality Spot-Check
+**Ticket**: ai-agentopia/agentopia-rag-platform#7
+**Date**: 2026-04-17
+**Scope**: `utop/oddspark` — Qdrant collection `kb-45294aa854667d3b`
+**Pipeline**: Pathway S3 → embed → Qdrant (`dev-46e4948`)
+**Source**: `s3://utop-oddspark-document/architecture/` (16 `.md` files)
+**Evaluator**: live cluster query against `agentopia-dev`, no synthetic data
+
+---
+
+## 1. Scope Restatement
+
+- Collection: `kb-45294aa854667d3b` (sha256("utop/oddspark")[:16])
+- Points inspected: all 16 (complete scan via Qdrant scroll)
+- Legacy baseline for comparison: collection `kb-1f28b6baebe4f76d` (260 points, knowledge-api/Super RAG path)
+- File types in scope: `.md` only — no DOCX/PDF in `architecture/` prefix
+
+---
+
+## 2. Documents and Chunks Inspected
+
+| Document | Text Len (chars) | Embed Coverage | Status |
+|---|---|---|---|
+| super-rag-debate.md | 57,778 | **52%** (truncated at 30k for embed) | PARTIAL EMBED |
+| a2a-improvement-plan.md | 37,114 | **81%** (truncated at 30k for embed) | PARTIAL EMBED |
+| a2a-solution-protocol.md | 24,849 | 100% | OK |
+| a2a-comparison.md | 19,205 | 100% | OK |
+| super-rag-blueprint.md | 18,449 | 100% | OK |
+| worker-pool-routing-improvement-plan.md | 13,726 | 100% | OK |
+| reviewer-remediation.md | 12,228 | 100% | OK |
+| p0.5-deterministic-delivery-start.md | 11,423 | 100% | OK |
+| overview.md | 11,064 | 100% | OK |
+| a2a-full-design.md | 8,526 | 100% | OK |
+| chatbot-architecture.md | 7,984 | 100% | OK |
+| architecture-multiple-bot.md | 6,695 | 100% | OK |
+| governed-pr-review-workflow.md | 5,506 | 100% | OK |
+| p1-execution-authorization.md | 5,223 | 100% | OK |
+| reviewer-coexistence.md | 4,697 | 100% | OK |
+| repo-split-notes.md | 1,038 | 100% | OK |
+
+**Chunk count**: 16 total (1 chunk per file — no sub-document splitting)
+**Mean chunk size**: 15,344 chars (~3,836 tokens)
+**Oversized for embedding**: 2 docs (37k + 57k chars, embed covers only 81% and 52% respectively)
+
+---
+
+## 3. Chunk Quality Findings
+
+### 3.1 Chunk Boundaries
+
+**Finding: No sub-document chunking. Each S3 object = exactly 1 chunk.**
+
+The pipeline uses `format="plaintext_by_object"` which reads the entire object as a single unit. There is no sentence-, paragraph-, or section-level splitting.
+
+Observed for `chatbot-architecture.md` (7,984 chars, 13 section headers):
+```
+## Key Capabilities
+## System Overview
+### Core Services
+## Bot Provisioning
+### Token Security
+## Memory Architecture
+### Scope-Based Isolation
+## Multi-Channel Support
+## Plugin System
+## MCP Tool Integration
+## LLM Proxy
+## GitOps and Deployment
+## Platform Roadmap
+```
+All 13 sections are concatenated into a single 7,984-char chunk. The single embedding vector averages over all sections, reducing retrieval precision for targeted queries.
+
+**For large docs**: `super-rag-debate.md` (57,778 chars) is stored intact but its embedding is derived only from the first 30,000 chars due to the token-limit truncation guard in `embed_text`. Content after position 30,000 (approximately the second half of this 12,000-word document) is unreachable via semantic search.
+
+**Coherence**: The text content itself is fully coherent and readable. No mid-word breaks, encoding issues, or garbled content observed across all 16 docs. YAML frontmatter is included in the stored text (not stripped) — this adds minor noise but does not break coherence.
+
+### 3.2 Text Integrity
+
+Text is clean, readable Markdown. Example from `chatbot-architecture.md`:
+```
+---
+title: "Agentopia Platform Architecture"
+description: "Technical architecture of the Agentopia multi-bot AI platform ..."
+---
+
+Agentopia is a self-hosted AI chatbot platform that lets organizations deploy multiple
+specialized AI bots with shared knowledge, long-term memory, and GitOps-native
+infrastructure on Kubernetes.
+
+## Key Capabilities
+...
+```
+No corruption, encoding artifacts, or truncation mid-word in any of the 16 chunks inspected.
+
+---
+
+## 4. Metadata Findings
+
+### 4.1 Actual Payload Schema (Pathway pipeline)
+
+```json
+{
+  "text": "...",                                         // str, full file content
+  "document_id": {"_value": "architecture/chatbot-architecture.md"},  // DICT — BUG
+  "section_path": {"_value": "architecture/chatbot-architecture.md"}, // DICT — BUG
+  "scope": "kb-45294aa854667d3b",                        // str, but wrong value
+  "status": "active"                                     // str, correct
+}
+```
+
+### 4.2 Metadata Issues
+
+**ISSUE M1 — CRITICAL: `document_id` and `section_path` serialized as dicts, not strings**
+
+Both fields are stored as `{"_value": "architecture/..."}` instead of `"architecture/..."`.
+
+Root cause: `pw.this._metadata["path"]` returns a Pathway-internal `ColumnReference` that wraps the value. When passed to `QdrantSink.on_change(row)`, the dict representation leaks into the payload instead of the unwrapped string.
+
+Impact: Any downstream code that reads `payload["document_id"]` and expects a string will receive a dict. Source attribution in gateway responses will render as `{'_value': 'architecture/chatbot-architecture.md'}` rather than the clean path. Filtering by `document_id` in Qdrant payload filters will fail to match string comparisons.
+
+Fix required in `pipeline.py`:
+```python
+# Current (broken):
+document_id=pw.this._metadata["path"],
+
+# Fix (extract string):
+document_id=pw.apply(lambda m: m["path"], pw.this._metadata),
+# or via UDF:
+@pw.udf
+def extract_path(meta: dict) -> str:
+    return meta["path"]
+document_id=extract_path(pw.this._metadata),
+```
+
+**ISSUE M2 — MODERATE: `scope` field contains collection name, not scope identity**
+
+`scope: "kb-45294aa854667d3b"` — the collection hash, not `"utop/oddspark"`.
+
+Impact: The scope field is used by gateway retrieval to filter chunks by scope. If the gateway filters on `scope == "utop/oddspark"`, no results are returned. If the gateway filters on the collection name, results work but traceability/display is degraded.
+
+Fix: Pass the human-readable scope (`QDRANT_COLLECTION` env var is the collection name; the source scope is `utop/oddspark`) — store `scope: "utop/oddspark"` in the payload.
+
+**ISSUE M3 — MODERATE: Missing metadata fields present in legacy system**
+
+| Field | Legacy Value | Pathway Value |
+|---|---|---|
+| `section` | `"5. Operational Notes"` | absent |
+| `chunk_index` | `8` | absent |
+| `total_chunks` | `11` | absent |
+| `ingested_at` | `1775195863.47` (unix ts) | absent |
+| `document_hash` | `"cf9dbf3c6e960..."` | absent |
+| `format` | `"markdown"` | absent |
+| `source_type` | `"business_doc"` | absent |
+
+The most impactful missing fields for retrieval quality:
+- `section`: used to identify which part of the document the chunk came from — entirely absent since there is no sub-chunking
+- `ingested_at`: prevents freshness filtering
+- `document_hash`: prevents deduplication/change detection
+
+**ISSUE M4 — MINOR: `section_path` duplicates `document_id` exactly**
+
+Both fields contain the same S3 object key. `section_path` is intended to encode a sub-document path (e.g., `"architecture/chatbot-architecture.md#Memory Architecture"`). Currently it carries no additional signal.
+
+### 4.3 Metadata Fields: What IS Correct
+
+- `text`: full document content, clean string ✅
+- `status: "active"`: correct ✅
+- All 16 points have identical schema (consistent) ✅
+
+---
+
+## 5. Embedding and Output Sanity
+
+| Check | Result |
+|---|---|
+| Vector dimensions | 1536 ✅ (matches text-embedding-3-small spec) |
+| Zero-value dimensions | 0 (all 1536 dims are nonzero) ✅ |
+| Vector magnitude range | min ≈ −0.18, max ≈ +0.10, mean ≈ 0.0 — normal distribution ✅ |
+| Collection status | `green` ✅ |
+| All 16 docs embedded | ✅ |
+| No failed embeddings | ✅ (zero errors in pipeline logs) |
+| Truncated docs (for embedding) | 2 docs (a2a-improvement-plan.md, super-rag-debate.md) — embed covers partial content ⚠ |
+
+Embedding quality is healthy for the 14 docs within the 30k-char limit. For the 2 oversized docs, the stored text is complete but the vector captures only the first portion of the document.
+
+---
+
+## 6. Comparison to Legacy / Expected Quality
+
+### Legacy pipeline (knowledge-api / Super RAG)
+
+**Baseline from `kb-1f28b6baebe4f76d` (260 points, same document types):**
+
+| Dimension | Legacy | Pathway (current) | Verdict |
+|---|---|---|---|
+| Chunks per file | ~16 avg (260 pts / ~16 docs) | 1 | WORSE |
+| Chunk size | 512 chars fixed | 1,038–57,778 chars | WORSE |
+| Semantic precision | Section-level (512-char window) | File-level (full document) | WORSE |
+| `document_id` type | string | dict `{'_value': '...'}` | BUG |
+| `section` metadata | present | absent | MISSING |
+| `chunk_index` / `total_chunks` | present | absent | MISSING |
+| `document_hash` | present | absent | MISSING |
+| Text coherence | clean | clean | EQUAL |
+| Embedding dims | 1536 | 1536 | EQUAL |
+| Oversized-for-embed docs | none (512-char chunks) | 2 of 16 | WORSE |
+
+### Quality Assessment
+
+The Pathway pipeline produces **structurally degraded output** compared to the legacy path on two material axes:
+
+1. **Retrieval precision (material)**: A query about "bot token security" would need to match against a 7,984-char embedding of `chatbot-architecture.md` that also includes 12 other sections. The legacy system embeds a 512-char chunk from the "Token Security" section specifically. For targeted questions, legacy wins on precision.
+
+2. **Metadata for traceability (material)**: Source attribution in LLM responses currently returns `{'_value': 'architecture/chatbot-architecture.md'}` — a dict, not a string. This is a functional defect in the current output, not a quality gap.
+
+**What is NOT worse**: The stored text is fully intact and coherent. A retrieval system that does full-document re-ranking against returned text would work correctly. The embedding distance is healthy. There is no data corruption.
+
+---
+
+## 7. Defect Summary
+
+| ID | Severity | Category | Description |
+|---|---|---|---|
+| D1 | CRITICAL | Metadata | `document_id` and `section_path` stored as `dict` not `str` (Pathway `_metadata["path"]` serialization) |
+| D2 | CRITICAL | Metadata | `scope` field = collection hash, not human-readable scope `utop/oddspark` |
+| D3 | MATERIAL | Chunking | No sub-document splitting: 1 file = 1 chunk regardless of size |
+| D4 | MATERIAL | Embedding | 2 docs exceed embed limit: embeddings cover only 52–81% of content |
+| D5 | MODERATE | Metadata | Missing: `section`, `chunk_index`, `total_chunks`, `ingested_at`, `document_hash` |
+| D6 | MINOR | Metadata | `section_path` = `document_id` (no sub-document granularity) |
+
+---
+
+## 8. Verdict
+
+**PARTIAL — accepted for P3.2 activation proof but NOT retrieval-ready without D1+D2 fixes**
+
+- P3.3 goal (validate ingest output quality) is satisfied: findings are concrete, grounded in live data, and defects are classified.
+- D1 (`document_id` dict bug) and D2 (`scope` wrong value) are blocking for production retrieval use. They do not block pipeline operation but will cause failures in any retrieval client that reads these fields as strings.
+- D3 (no sub-chunking) is a known architectural trade-off of the Phase 3 MVP using `plaintext_by_object`. Sub-chunking is deferred to a later ticket.
+- D4 (partial embedding for 2 oversized docs) is accepted with the existing truncation guard as a temporary measure.
+
+**Required before retrieval integration**: Fix D1 and D2 in `pipeline.py`. Defects D3–D6 are acceptable-with-notes for the current milestone.
+
+---
+
+## 9. Next Recommended Ticket
+
+Fix the two critical metadata defects before proceeding to retrieval evaluation:
+- **D1 fix**: Change `pw.this._metadata["path"]` extraction to unwrap the string value in `pipeline.py`
+- **D2 fix**: Store `scope` as the human-readable scope identity, not the collection name
+
+These are targeted `pipeline.py` changes, not architectural rewrites. Once fixed, retrieval integration can proceed.


### PR DESCRIPTION
## Summary

Live spot-check of Pathway ingest output against collection `kb-45294aa854667d3b` (scope `utop/oddspark`, 16 `.md` docs from `s3://utop-oddspark-document/architecture/`).

## Critical Findings (D1, D2)

- **D1**: `document_id` and `section_path` stored as `{'_value': '...'}` dict instead of string — Pathway `_metadata["path"]` serialization bug. Breaks all retrieval clients expecting string source attribution.
- **D2**: `scope` field contains collection hash `kb-45294aa854667d3b` instead of human-readable `utop/oddspark`. Scope filtering will fail in gateway retrieval.

## Other Findings

- **D3**: No sub-document chunking (1 file = 1 chunk, mean 15,344 chars — legacy path produced 512-char section-aware chunks)
- **D4**: 2 docs exceed embed limit: 37k and 57k chars — embeddings cover 81% and 52% of content respectively
- **D5**: Missing metadata fields present in legacy: `section`, `chunk_index`, `total_chunks`, `document_hash`

## Verdict

PARTIAL — pipeline operational and ingest proven, D1+D2 must be fixed before retrieval integration.

Full report: `src/eval/results/p3.3-chunk-quality-spot-check.md`

Ticket: ai-agentopia/agentopia-rag-platform#7