### PR TITLE
fix(pipeline): correct metadata bugs D1/D2/D5a/D5b (Ticket A)

### DIFF
--- a/src/ingest/pipeline.py
+++ b/src/ingest/pipeline.py
@@ -6,6 +6,7 @@ Reads documents from S3, chunks + embeds them, and upserts into Qdrant.
 All configuration is via environment variables (set from K8s Secrets):
   QDRANT_URL           — e.g. http://qdrant:6333
   QDRANT_COLLECTION    — target collection name, e.g. kb-<scope_hash>
+  SCOPE_IDENTITY       — human-readable scope, e.g. utop/oddspark (default: QDRANT_COLLECTION)
   S3_BUCKET_NAME       — source S3 bucket
   S3_PREFIX            — object prefix to poll, e.g. scopes/{scope}/
   S3_REGION            — AWS region
@@ -20,6 +21,7 @@ All configuration is via environment variables (set from K8s Secrets):
 
 import hashlib
 import os
+import time as _time
 
 import pathway as pw
 from openai import OpenAI
@@ -49,6 +51,10 @@ EMBEDDING_MODEL = os.environ.get("EMBEDDING_MODEL", "text-embedding-3-small")
 
 POLL_INTERVAL = int(os.environ.get("PATHWAY_POLL_INTERVAL_SECS", "30"))
 STATE_DIR = os.environ.get("PATHWAY_STATE_DIR", "/var/pathway/state")
+# Human-readable scope identity stored in Qdrant payload (e.g. "utop/oddspark").
+# Defaults to QDRANT_COLLECTION (collection hash) if not explicitly set.
+# Set SCOPE_IDENTITY to the source scope for correct gateway retrieval filtering.
+SCOPE_IDENTITY = os.environ.get("SCOPE_IDENTITY", QDRANT_COLLECTION)
 
 VECTOR_DIM = 1536  # text-embedding-3-small output dimension
 # text-embedding-3-small max input: 8191 tokens (~4 chars/token).
@@ -70,6 +76,17 @@ def embed_text(text: str) -> list:
         text = text[:_MAX_EMBED_CHARS]
     resp = _openai_client.embeddings.create(input=text, model=EMBEDDING_MODEL)
     return resp.data[0].embedding
+
+
+@pw.udf
+def extract_path(meta: dict) -> str:
+    """Extract the S3 object key from Pathway _metadata as a plain string.
+
+    pw.this._metadata["path"] returns a Pathway ColumnReference that serialises
+    as {"_value": "..."} when passed directly through select(). This UDF unwraps
+    the value so document_id and section_path are stored as strings in Qdrant.
+    """
+    return meta.get("path", "")
 
 
 # ---------------------------------------------------------------------------
@@ -117,10 +134,21 @@ class QdrantSink(pw.io.python.ConnectorObserver):
                         vector=row["embedding"],
                         payload={
                             "document_id": row.get("document_id", ""),
-                            "scope": QDRANT_COLLECTION,
+                            "scope": SCOPE_IDENTITY,
                             "section_path": row.get("section_path", ""),
                             "text": row.get("text", ""),
                             "status": "active",
+                            # document_hash: SHA-256 of stored text — enables deduplication
+                            # and change detection without re-fetching from S3.
+                            "document_hash": hashlib.sha256(
+                                row.get("text", "").encode()
+                            ).hexdigest(),
+                            # ingested_at: wall-clock Unix timestamp (seconds) when this
+                            # chunk was written to Qdrant. Pathway's `time` parameter is a
+                            # logical batch epoch in ms (autocommit_duration_ms cycles) —
+                            # NOT wall-clock time. _time.time() is the correct source for
+                            # freshness lag measurement (P3.5).
+                            "ingested_at": _time.time(),
                         },
                     )
                 ],
@@ -156,10 +184,12 @@ def build_pipeline() -> None:
     )
 
     # -- Transform: derive document_id and section_path from S3 object key ----
+    # extract_path UDF unwraps pw.this._metadata to a plain string.
+    # Direct pw.this._metadata["path"] serialises as {"_value": "..."} (dict bug).
     documents = documents.select(
         text=pw.this.data,
-        document_id=pw.this._metadata["path"],
-        section_path=pw.this._metadata["path"],
+        document_id=extract_path(pw.this._metadata),
+        section_path=extract_path(pw.this._metadata),
     )
 
     # -- Transform: embed each document chunk ---------------------------------


### PR DESCRIPTION
## Summary

Fixes the four critical/material metadata defects identified in the P3.3 chunk quality spot-check (ai-agentopia/agentopia-rag-platform#7).

- **D1**: Add `extract_path` UDF to unwrap `pw.this._metadata` as a plain string. Direct `_metadata["path"]` subscript leaks a Pathway `ColumnReference` into `on_change` row, serialising as `{"_value": "..."}` instead of a string. Any downstream code reading `document_id` as a string would break.
- **D2**: Read `SCOPE_IDENTITY` env var and store it as the `scope` field instead of `QDRANT_COLLECTION` (collection hash). Restores gateway retrieval filtering by human-readable scope (e.g. `utop/oddspark`).
- **D5a**: Add `document_hash` (SHA-256 of stored text) to enable deduplication and change detection without re-fetching from S3.
- **D5b**: Add `ingested_at` as wall-clock `time.time()`. Pathway's `time` parameter in `on_change` is a logical batch epoch in ms (autocommit_duration_ms cycles), not wall-clock time — using it would produce misleading freshness timestamps. Required for P3.5 freshness lag measurement.

## Infra dependency

Requires `agentopia-infra` chart PR (adds `SCOPE_IDENTITY` env var to Deployment) and ArgoCD dev override (`scope.identity: "utop/oddspark"` in `argocd/dev/pathway-pipeline.yaml`). Both are already pushed/merged on the infra side.

## After merge

Pipeline pod must be restarted with state wipe to re-index all 16 docs with corrected metadata. Acceptance: Qdrant scroll showing `document_id` as plain string, `scope` as `"utop/oddspark"`, `document_hash` as 64-char hex, `ingested_at` as Unix float.

## Test plan
- [ ] Build passes CI (`dev-{sha}` image pushed)
- [ ] ArgoCD Image Updater applies new image tag to pipeline pod
- [ ] Delete Pathway state PVC to force full re-index
- [ ] Qdrant scroll: verify `document_id` is string (not dict)
- [ ] Qdrant scroll: verify `scope` is `"utop/oddspark"` (not `"kb-45294aa854667d3b"`)
- [ ] Qdrant scroll: verify `document_hash` is 64-char hex
- [ ] Qdrant scroll: verify `ingested_at` is a Unix float (current time)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)