### PR TITLE
fix(pipeline): fix extract_path UDF — pass path str not metadata dict

### DIFF
--- a/src/ingest/pipeline.py
+++ b/src/ingest/pipeline.py
@@ -79,14 +79,19 @@ def embed_text(text: str) -> list:
 
 
 @pw.udf
-def extract_path(meta: dict) -> str:
-    """Extract the S3 object key from Pathway _metadata as a plain string.
+def extract_path(path: str) -> str:
+    """Return the S3 object key as a plain Python string.
 
-    pw.this._metadata["path"] returns a Pathway ColumnReference that serialises
-    as {"_value": "..."} when passed directly through select(). This UDF unwraps
-    the value so document_id and section_path are stored as strings in Qdrant.
+    pw.this._metadata["path"] in select() keeps a Pathway-internal wrapper type
+    that serialises as {"_value": "..."} when read in on_change rows. Passing it
+    through this UDF (with `path: str` annotation) forces Pathway to evaluate and
+    unwrap the value to a plain str at the UDF boundary.
+
+    Note: the parameter is pw.this._metadata["path"] (the path field), NOT the
+    whole _metadata dict. Passing the whole _metadata produces a Json object that
+    has no `.get()` method — that is the bug this UDF avoids.
     """
-    return meta.get("path", "")
+    return path
 
 
 # ---------------------------------------------------------------------------
@@ -184,12 +189,13 @@ def build_pipeline() -> None:
     )
 
     # -- Transform: derive document_id and section_path from S3 object key ----
-    # extract_path UDF unwraps pw.this._metadata to a plain string.
-    # Direct pw.this._metadata["path"] serialises as {"_value": "..."} (dict bug).
+    # extract_path UDF takes _metadata["path"] (str), not the full _metadata dict.
+    # Without the UDF, _metadata["path"] in select() retains an internal wrapper
+    # type that serialises as {"_value": "..."} in on_change rows.
     documents = documents.select(
         text=pw.this.data,
-        document_id=extract_path(pw.this._metadata),
-        section_path=extract_path(pw.this._metadata),
+        document_id=extract_path(pw.this._metadata["path"]),
+        section_path=extract_path(pw.this._metadata["path"]),
     )
 
     # -- Transform: embed each document chunk ---------------------------------


### PR DESCRIPTION
## Root cause

`dev-3cb09c4` CrashLoopBackOff: `AttributeError: 'Json' object has no attribute 'get'`

Pathway passes `_metadata` to a UDF as a `Json` object (Pathway-internal type), not a Python `dict`. The previous fix annotated the UDF parameter as `meta: dict` and called `meta.get("path", "")` — both assumptions were wrong.

## Fix

- Change `extract_path(meta: dict)` → `extract_path(path: str)`
- Change call site from `extract_path(pw.this._metadata)` → `extract_path(pw.this._metadata["path"])`
- UDF body: just `return path`

Pathway evaluates `_metadata["path"]` and converts it to `str` (per UDF type annotation) at the UDF boundary, producing a plain Python string in the `on_change` row dict. This is the correct approach to unwrap Pathway's internal wrapper type.

## What this still fixes (D1)

`pw.this._metadata["path"]` in `select()` without a UDF retains an internal Pathway wrapper that serialises as `{"_value": "..."}` in `on_change` rows. The UDF boundary (with `str` annotation) strips that wrapper. D1 fix still applies.

D2 (`SCOPE_IDENTITY`), D5a (`document_hash`), D5b (`ingested_at`) are unchanged.

## Test plan
- [ ] CI builds `dev-{sha}` from this commit
- [ ] Image Updater applies new tag
- [ ] Pod starts without CrashLoopBackOff
- [ ] Qdrant scroll: `document_id` is plain string (not dict)
- [ ] Qdrant scroll: `scope` = `"utop/oddspark"`
- [ ] Qdrant scroll: `document_hash` is 64-char hex
- [ ] Qdrant scroll: `ingested_at` is Unix float

🤖 Generated with [Claude Code](https://claude.ai/claude-code)