### PR TITLE
fix(pipeline): strip JSON string quotes from _unwrap_json

### DIFF
--- a/src/ingest/pipeline.py
+++ b/src/ingest/pipeline.py
@@ -82,12 +82,20 @@ def _unwrap_json(val: object) -> str:
     """Unwrap a Pathway Json column value from its ConnectorObserver row form.
 
     When a pw.Json-typed column (e.g. pw.this._metadata["path"]) is observed
-    via pw.io.python.ConnectorObserver, Pathway serialises primitive values as
-    {"_value": actual_value} in the on_change row dict. This helper extracts
-    the actual string, handling both the wrapped and plain-string cases.
+    via pw.io.python.ConnectorObserver, Pathway serialises the value as:
+        {"_value": json_encoded_value}
+    where json_encoded_value is the JSON representation of the primitive. For
+    strings, this means the _value field contains the string WITH surrounding
+    double-quote characters (e.g. '"architecture/chatbot-architecture.md"').
+    This helper extracts and unquotes the actual plain string.
     """
     if isinstance(val, dict) and "_value" in val:
-        return str(val["_value"])
+        inner = val["_value"]
+        # Strip JSON string quotes: Pathway JSON-encodes string values in _value,
+        # so a path "architecture/foo.md" is stored as '"architecture/foo.md"'.
+        if isinstance(inner, str) and len(inner) >= 2 and inner[0] == '"' and inner[-1] == '"':
+            return inner[1:-1]
+        return str(inner) if inner is not None else ""
     if val is None:
         return ""
     return str(val)


### PR DESCRIPTION
## Root cause

Live Qdrant verification revealed `document_id` stored as `"architecture/chatbot-architecture.md"` (38 chars, with surrounding double-quote chars), not `architecture/chatbot-architecture.md` (36 chars, no quotes).

Pathway's `ConnectorObserver.on_change` serialises `pw.Json`-typed columns as `{"_value": json_repr}` where `json_repr` is the **JSON encoding** of the value. For string values, this means `_value` is the JSON string representation — including surrounding `"` characters.

Previous `_unwrap_json` did `str(val["_value"])` which preserved those surrounding quotes in the output.

## Fix

Detect JSON-quoted strings in `_value` (starts and ends with `"`) and strip them. S3 object keys are plain paths — no embedded quotes or escape sequences — so simple `inner[1:-1]` strip is safe and correct.

## Test plan
- [ ] Qdrant `document_id` = `architecture/chatbot-architecture.md` (no surrounding quotes)
- [ ] `section_path` same pattern
- [ ] All 16 points pass full payload check

🤖 Generated with [Claude Code](https://claude.ai/claude-code)