### PR TITLE
fix(pipeline): handle plain-string form of Pathway pw.Json in _unwrap_json

### DIFF
--- a/src/ingest/pipeline.py
+++ b/src/ingest/pipeline.py
@@ -81,23 +81,25 @@ def embed_text(text: str) -> list:
 def _unwrap_json(val: object) -> str:
     """Unwrap a Pathway Json column value from its ConnectorObserver row form.
 
-    When a pw.Json-typed column (e.g. pw.this._metadata["path"]) is observed
-    via pw.io.python.ConnectorObserver, Pathway serialises the value as:
-        {"_value": json_encoded_value}
-    where json_encoded_value is the JSON representation of the primitive. For
-    strings, this means the _value field contains the string WITH surrounding
-    double-quote characters (e.g. '"architecture/chatbot-architecture.md"').
-    This helper extracts and unquotes the actual plain string.
+    Pathway may deliver pw.Json-typed columns in two forms depending on version:
+      Form A — dict wrapper:  {"_value": json_encoded_value}
+      Form B — plain string:  '"architecture/chatbot-architecture.md"'
+                               (the raw JSON encoding, quotes included)
+
+    In both cases the JSON encoding of a string value includes surrounding
+    double-quote characters that must be stripped to obtain the plain path.
     """
     if isinstance(val, dict) and "_value" in val:
         inner = val["_value"]
-        # Strip JSON string quotes: Pathway JSON-encodes string values in _value,
-        # so a path "architecture/foo.md" is stored as '"architecture/foo.md"'.
+        # Strip JSON string quotes from dict-wrapped form.
         if isinstance(inner, str) and len(inner) >= 2 and inner[0] == '"' and inner[-1] == '"':
             return inner[1:-1]
         return str(inner) if inner is not None else ""
     if val is None:
         return ""
+    # Strip JSON string quotes from plain-string form (Form B).
+    if isinstance(val, str) and len(val) >= 2 and val[0] == '"' and val[-1] == '"':
+        return val[1:-1]
     return str(val)
 
 


### PR DESCRIPTION
## Root Cause

`_unwrap_json` was only handling Form A of Pathway's `pw.Json` serialization:

```
Form A: {"_value": '"path/to/file.md"'}  — dict wrapper
Form B: '"path/to/file.md"'              — raw JSON-encoded string (plain str)
```

When Pathway delivers `pw.Json` as Form B, the `isinstance(val, dict)` guard is False and execution falls through to `return str(val)`, which returns the value **unchanged** — preserving the surrounding double-quote characters in the Qdrant `document_id` / `section_path` payload.

This caused D1 acceptance criteria to fail: `document_id='"architecture/foo.md"'` instead of `'architecture/foo.md'`.

## Fix

Add quote-stripping for the plain-string path (Form B) before the final `return str(val)` fallback.

## Verification

After merge → CI build → ArgoCD rollout:
1. Wipe Pathway state PVC
2. Force pod restart (reindex all 16 S3 objects)
3. Run Wave D Qdrant verification — expect D1 to PASS on all points