### PR TITLE
fix(pipeline): use json.loads to decode pw.Json column values in _unwrap_json

### DIFF
--- a/src/ingest/pipeline.py
+++ b/src/ingest/pipeline.py
@@ -20,6 +20,7 @@ All configuration is via environment variables (set from K8s Secrets):
 """
 
 import hashlib
+import json
 import os
 import time as _time
 
@@ -81,26 +82,37 @@ def embed_text(text: str) -> list:
 def _unwrap_json(val: object) -> str:
     """Unwrap a Pathway Json column value from its ConnectorObserver row form.
 
-    Pathway may deliver pw.Json-typed columns in two forms depending on version:
-      Form A — dict wrapper:  {"_value": json_encoded_value}
-      Form B — plain string:  '"architecture/chatbot-architecture.md"'
-                               (the raw JSON encoding, quotes included)
+    Pathway delivers pw.Json-typed columns (e.g. pw.this._metadata["path"]) as
+    one of three forms in on_change row dicts:
+      Form A — dict wrapper:  {"_value": '"path/to/file.md"'}
+      Form B — plain str:     '"path/to/file.md"'  (raw JSON text, Python str type)
+      Form C — pw.Json obj:   str(val) == '"path/to/file.md"'  (not a plain str/dict)
 
-    In both cases the JSON encoding of a string value includes surrounding
-    double-quote characters that must be stripped to obtain the plain path.
+    In all cases str(val) produces the JSON-encoded representation of the value,
+    so json.loads(str(val)) is the correct canonical decoder.  Form A is handled
+    via the dict branch for safety; Forms B and C fall through to json.loads.
     """
     if isinstance(val, dict) and "_value" in val:
+        # Form A: unwrap the _value key, then json-decode to strip JSON encoding.
         inner = val["_value"]
-        # Strip JSON string quotes from dict-wrapped form.
-        if isinstance(inner, str) and len(inner) >= 2 and inner[0] == '"' and inner[-1] == '"':
-            return inner[1:-1]
-        return str(inner) if inner is not None else ""
+        try:
+            decoded = json.loads(inner) if isinstance(inner, str) else inner
+            return str(decoded) if decoded is not None else ""
+        except (json.JSONDecodeError, ValueError):
+            return str(inner) if inner is not None else ""
     if val is None:
         return ""
-    # Strip JSON string quotes from plain-string form (Form B).
-    if isinstance(val, str) and len(val) >= 2 and val[0] == '"' and val[-1] == '"':
-        return val[1:-1]
-    return str(val)
+    # Forms B and C: str() of the value is a JSON-encoded string.
+    # json.loads strips the surrounding double-quote characters produced by
+    # Pathway's JSON serialization of string values.
+    s = str(val)
+    try:
+        decoded = json.loads(s)
+        if isinstance(decoded, str):
+            return decoded
+    except (json.JSONDecodeError, ValueError):
+        pass
+    return s
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Root Cause (definitive)

After running with the pod live, the actual Pathway runtime delivers `pw.Json`-typed columns as **Form C**: a `pw.Json` object (not `dict`, not plain `str`). Previous fixes only handled Forms A and B:

| Form | Type | Previous behavior | Now |
|------|------|-------------------|-----|
| A | `{"_value": '"path"'}` | ✅ extracted inner, stripped quotes | ✅ same + json.loads |
| B | `'"path"'` (Python str) | ✅ stripped quotes in #38 | ✅ json.loads |
| C | `pw.Json` object | ❌ `isinstance(val,str)` False → `str(val)` returned raw JSON text | ✅ `json.loads(str(val))` |

`str(pw.Json("path"))` = `'"path"'` — the raw JSON encoding including surrounding double-quote characters. `json.loads(str(val))` is the correct canonical decoder for all three forms since `str()` always produces JSON text.

## Evidence

Pod `agentopia-rag-platform-7799c5979b-9chm6` running `dev-b1b7215` (which had the Form B fix) was verified live after a full reindex (state wipe + 16 PUT requests confirmed in logs at 01:41:48–01:42:05 UTC). All 16 Qdrant points still showed `document_id='"architecture/..."'` (with surrounding quotes) — proving that `isinstance(val, str)` was not matching.

## Verification (post-merge)

After rollout:
1. Wipe Pathway state PVC
2. Force pod restart → 16 S3 objects re-indexed
3. Run Wave D verification — expect all 16 points: D1 `document_id` plain string, D2 `scope=utop/oddspark`, D5a `document_hash` 64-char hex, D5b `ingested_at` unix float