### PR TITLE
chore(p3.6): retrieval eval gate — nDCG@5=0.9410 PASS

### DIFF
--- a/src/eval/datasets/p3_pilot_gate.json
+++ b/src/eval/datasets/p3_pilot_gate.json
@@ -1,0 +1,101 @@
+{
+  "version": "1.0",
+  "phase": "p3",
+  "scope": "utop/oddspark",
+  "collection": "kb-45294aa854667d3b",
+  "description": "P3.6 retrieval eval gate — 10 queries grounded in the live utop/oddspark corpus (architecture/ prefix, 16 markdown documents, chunked by Pathway pipeline). Document-level relevance judgments: matching on document_id (S3 key). Grading scale 0-2.",
+  "grading_scale": {
+    "0": "irrelevant — chunk is from a document that does not address the query",
+    "1": "partially relevant — chunk is from a document with related but indirect information",
+    "2": "fully relevant — chunk is from a document that directly answers the query"
+  },
+  "matching_strategy": "document_id — a retrieved chunk is graded by its parent document's relevance to the query, not by exact chunk_index. This is appropriate for document-level retrieval quality gating on a corpus where each document covers a coherent topic.",
+  "samples": [
+    {
+      "id": "p3-01",
+      "query": "How does the A2A protocol compare between BeeAI framework and Agentopia implementations?",
+      "scenario": "factual_comparison",
+      "relevant_documents": [
+        {"document_id": "architecture/a2a-comparison.md", "relevance": 2, "reason": "Directly compares BeeAI vs Agentopia A2A implementations"},
+        {"document_id": "architecture/a2a-full-design.md", "relevance": 1, "reason": "Covers Agentopia A2A design but not BeeAI comparison"}
+      ]
+    },
+    {
+      "id": "p3-02",
+      "query": "How does the multi-bot memory architecture work with shared knowledge and isolated identities?",
+      "scenario": "architecture_explanation",
+      "relevant_documents": [
+        {"document_id": "architecture/architecture-multiple-bot.md", "relevance": 2, "reason": "Directly addresses multi-bot memory architecture with shared/isolated concepts"},
+        {"document_id": "architecture/chatbot-architecture.md", "relevance": 1, "reason": "General chatbot architecture with memory references"}
+      ]
+    },
+    {
+      "id": "p3-03",
+      "query": "What retrieval strategy was chosen for the Super RAG system and what alternatives were considered?",
+      "scenario": "design_decision",
+      "relevant_documents": [
+        {"document_id": "architecture/super-rag-debate.md", "relevance": 2, "reason": "CTO debate session covering retrieval strategy options and decisions"},
+        {"document_id": "architecture/super-rag-blueprint.md", "relevance": 2, "reason": "Blueprint with recommended retrieval stack"}
+      ]
+    },
+    {
+      "id": "p3-04",
+      "query": "How does the automated code review workflow enforce quality gates on pull requests?",
+      "scenario": "process_explanation",
+      "relevant_documents": [
+        {"document_id": "architecture/governed-pr-review-workflow.md", "relevance": 2, "reason": "Directly describes the governed PR review workflow"},
+        {"document_id": "architecture/reviewer-remediation.md", "relevance": 1, "reason": "Covers reviewer remediation which is related but not the core workflow"}
+      ]
+    },
+    {
+      "id": "p3-05",
+      "query": "What is the dual-lane interaction model in the Agentopia platform architecture?",
+      "scenario": "architecture_concept",
+      "relevant_documents": [
+        {"document_id": "architecture/overview.md", "relevance": 2, "reason": "Architecture overview that defines the dual-lane interaction model"}
+      ]
+    },
+    {
+      "id": "p3-06",
+      "query": "How does the deterministic delivery pipeline start and execute tasks?",
+      "scenario": "process_explanation",
+      "relevant_documents": [
+        {"document_id": "architecture/p0.5-deterministic-delivery-start.md", "relevance": 2, "reason": "Directly describes the deterministic delivery start process"}
+      ]
+    },
+    {
+      "id": "p3-07",
+      "query": "What are the implementation phases for the production-ready A2A solution protocol?",
+      "scenario": "planning_detail",
+      "relevant_documents": [
+        {"document_id": "architecture/a2a-solution-protocol.md", "relevance": 2, "reason": "Contains the A2A solution protocol with implementation phases"},
+        {"document_id": "architecture/a2a-improvement-plan.md", "relevance": 2, "reason": "A2A improvement plan with phased implementation"}
+      ]
+    },
+    {
+      "id": "p3-08",
+      "query": "How does the worker pool handle routing improvements for task distribution?",
+      "scenario": "architecture_detail",
+      "relevant_documents": [
+        {"document_id": "architecture/worker-pool-routing-improvement-plan.md", "relevance": 2, "reason": "Directly addresses worker pool routing improvements"}
+      ]
+    },
+    {
+      "id": "p3-09",
+      "query": "How are conflicts resolved when multiple review systems coexist in the codebase?",
+      "scenario": "process_explanation",
+      "relevant_documents": [
+        {"document_id": "architecture/reviewer-coexistence.md", "relevance": 2, "reason": "Directly addresses reviewer coexistence and conflict resolution"},
+        {"document_id": "architecture/reviewer-remediation.md", "relevance": 1, "reason": "Related remediation process for reviewers"}
+      ]
+    },
+    {
+      "id": "p3-10",
+      "query": "What are the execution authorization requirements and gate criteria for P1?",
+      "scenario": "gate_criteria",
+      "relevant_documents": [
+        {"document_id": "architecture/p1-execution-authorization.md", "relevance": 2, "reason": "Directly specifies P1 execution authorization requirements"}
+      ]
+    }
+  ]
+}

--- a/src/eval/p3_pilot_gate.py
+++ b/src/eval/p3_pilot_gate.py
@@ -1,0 +1,226 @@
+"""P3.6 retrieval eval gate — nDCG@5 on live chunked pilot scope.
+
+Queries the Qdrant collection directly using the same embedding model
+as the Pathway pipeline.  Grades results using document-level relevance
+judgments from the eval dataset.
+
+Usage (from pod or with port-forwarded Qdrant):
+    python src/eval/p3_pilot_gate.py \
+        --qdrant-url http://qdrant:6333 \
+        --collection kb-45294aa854667d3b \
+        --dataset src/eval/datasets/p3_pilot_gate.json
+
+Usage (from local machine via SSH):
+    Copy to pod and run, or port-forward Qdrant 6333.
+"""
+
+import argparse
+import json
+import math
+import os
+import sys
+from datetime import datetime, timezone
+
+
+# ── Metrics (self-contained, matches retrieval_metrics.py in super-rag) ──
+
+
+def dcg_at_k(relevances: list, k: int) -> float:
+    score = 0.0
+    for i, rel in enumerate(relevances[:k]):
+        score += rel / math.log2(i + 2)
+    return score
+
+
+def ndcg_at_k(relevances: list, k: int) -> float:
+    dcg = dcg_at_k(relevances, k)
+    ideal = sorted(relevances, reverse=True)
+    idcg = dcg_at_k(ideal, k)
+    return dcg / idcg if idcg > 0 else 0.0
+
+
+def mrr(relevances: list, threshold: float = 1.0) -> float:
+    for i, rel in enumerate(relevances):
+        if rel >= threshold:
+            return 1.0 / (i + 1)
+    return 0.0
+
+
+def precision_at_k(relevances: list, k: int, threshold: float = 1.0) -> float:
+    top_k = relevances[:k]
+    if not top_k:
+        return 0.0
+    return sum(1 for r in top_k if r >= threshold) / len(top_k)
+
+
+def recall_at_k(relevances: list, k: int, total_relevant: int, threshold: float = 1.0) -> float:
+    if total_relevant == 0:
+        return 0.0
+    return sum(1 for r in relevances[:k] if r >= threshold) / total_relevant
+
+
+# ── Retrieval ──
+
+
+def embed_query(text: str, client, model: str) -> list:
+    resp = client.embeddings.create(input=text, model=model)
+    return resp.data[0].embedding
+
+
+def search_qdrant(qc, collection: str, embedding: list, limit: int = 5) -> list:
+    results = qc.query_points(
+        collection_name=collection,
+        query=embedding,
+        limit=limit,
+        with_payload=True,
+    )
+    return results.points
+
+
+# ── Grading ──
+
+
+def grade_results(points: list, relevant_docs: list, k: int) -> dict:
+    """Grade retrieved points against document-level relevance judgments."""
+    doc_relevance = {d["document_id"]: d["relevance"] for d in relevant_docs}
+
+    relevances = []
+    detail = []
+    for rank, pt in enumerate(points[:k]):
+        payload = pt.payload or {}
+        doc_id = payload.get("document_id", "")
+        grade = doc_relevance.get(doc_id, 0)
+        relevances.append(float(grade))
+        detail.append({
+            "rank": rank + 1,
+            "document_id": doc_id,
+            "section": payload.get("section", ""),
+            "chunk_index": payload.get("chunk_index", -1),
+            "score": round(pt.score, 4) if hasattr(pt, "score") else 0.0,
+            "relevance_grade": grade,
+            "text_preview": payload.get("text", "")[:80],
+        })
+
+    total_relevant = sum(1 for d in relevant_docs if d["relevance"] >= 1)
+
+    metrics = {
+        "ndcg": round(ndcg_at_k(relevances, k), 4),
+        "mrr": round(mrr(relevances), 4),
+        "precision": round(precision_at_k(relevances, k), 4),
+        "recall": round(recall_at_k(relevances, k, total_relevant), 4),
+    }
+
+    return {
+        "relevances": relevances,
+        "metrics": metrics,
+        "detail": detail,
+        "total_relevant": total_relevant,
+    }
+
+
+# ── Main ──
+
+
+def run_eval(args):
+    from openai import OpenAI
+    from qdrant_client import QdrantClient
+
+    with open(args.dataset) as f:
+        dataset = json.load(f)
+
+    qc = QdrantClient(url=args.qdrant_url)
+    openai_client = OpenAI(
+        api_key=args.embedding_api_key or os.environ.get("EMBEDDING_API_KEY", ""),
+        base_url=args.embedding_base_url or os.environ.get("EMBEDDING_BASE_URL", "https://api.openai.com/v1"),
+    )
+    model = args.embedding_model or os.environ.get("EMBEDDING_MODEL", "text-embedding-3-small")
+    k = args.k
+
+    per_query = []
+    for sample in dataset["samples"]:
+        sid = sample["id"]
+        query = sample["query"]
+        print(f"  [{sid}] {query[:70]}...", end=" ", flush=True)
+
+        embedding = embed_query(query, openai_client, model)
+        points = search_qdrant(qc, args.collection, embedding, limit=k)
+        grading = grade_results(points, sample["relevant_documents"], k)
+
+        print(f"nDCG@{k}={grading['metrics']['ndcg']:.4f}  MRR={grading['metrics']['mrr']:.4f}")
+
+        per_query.append({
+            "id": sid,
+            "query": query,
+            "scenario": sample.get("scenario", ""),
+            **grading,
+        })
+
+    # Aggregate
+    agg = {}
+    for metric in ["ndcg", "mrr", "precision", "recall"]:
+        values = [q["metrics"][metric] for q in per_query]
+        agg[metric] = {
+            "mean": round(sum(values) / len(values), 4) if values else None,
+            "min": round(min(values), 4) if values else None,
+            "max": round(max(values), 4) if values else None,
+            "count": len(values),
+        }
+
+    ts = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+    result = {
+        "phase": "p3",
+        "type": "pilot_gate",
+        "timestamp": ts,
+        "scope": dataset.get("scope", ""),
+        "collection": args.collection,
+        "dataset": args.dataset,
+        "matching_strategy": dataset.get("matching_strategy", ""),
+        "k": k,
+        "sample_count": len(per_query),
+        "aggregates": agg,
+        "per_query": per_query,
+        "gate": {
+            "threshold": 0.90,
+            "baseline_reference": 0.925,
+            "ndcg_mean": agg["ndcg"]["mean"],
+            "passed": agg["ndcg"]["mean"] is not None and agg["ndcg"]["mean"] >= 0.90,
+        },
+    }
+
+    os.makedirs(args.output_dir, exist_ok=True)
+    out_path = os.path.join(args.output_dir, "nDCG-p3-pilot-gate.json")
+    with open(out_path, "w") as f:
+        json.dump(result, f, indent=2)
+
+    print()
+    print(f"=== P3.6 Retrieval Eval Gate ===")
+    print(f"Scope:      {dataset.get('scope', '?')}")
+    print(f"Collection: {args.collection}")
+    print(f"Queries:    {len(per_query)}")
+    print(f"K:          {k}")
+    print()
+    for metric in ["ndcg", "mrr", "precision", "recall"]:
+        label = {"ndcg": "nDCG@5", "mrr": "MRR", "precision": "P@5", "recall": "R@5"}[metric]
+        a = agg[metric]
+        print(f"  {label:10s}  mean={a['mean']:.4f}  min={a['min']:.4f}  max={a['max']:.4f}")
+    print()
+    print(f"Gate threshold:   nDCG@5 >= 0.90")
+    print(f"Baseline ref:     nDCG@5 = 0.925 (P0.1)")
+    print(f"Result:           nDCG@5 = {agg['ndcg']['mean']:.4f}")
+    print(f"Verdict:          {'PASS' if result['gate']['passed'] else 'FAIL'}")
+    print(f"\nArtifact: {out_path}")
+
+    return result
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="P3.6 retrieval eval gate")
+    parser.add_argument("--qdrant-url", default="http://qdrant.agentopia-dev.svc.cluster.local:6333")
+    parser.add_argument("--collection", default="kb-45294aa854667d3b")
+    parser.add_argument("--dataset", default="src/eval/datasets/p3_pilot_gate.json")
+    parser.add_argument("--output-dir", default="src/eval/results")
+    parser.add_argument("--embedding-base-url", default=None)
+    parser.add_argument("--embedding-api-key", default=None)
+    parser.add_argument("--embedding-model", default=None)
+    parser.add_argument("--k", type=int, default=5)
+    run_eval(parser.parse_args())

--- a/src/eval/results/nDCG-p3-pilot-gate.json
+++ b/src/eval/results/nDCG-p3-pilot-gate.json
@@ -1,0 +1,705 @@
+{
+  "phase": "p3",
+  "type": "pilot_gate",
+  "timestamp": "20260418T042351Z",
+  "scope": "utop/oddspark",
+  "collection": "kb-45294aa854667d3b",
+  "dataset": "/tmp/eval/datasets/p3_pilot_gate.json",
+  "matching_strategy": "document_id \u2014 a retrieved chunk is graded by its parent document's relevance to the query, not by exact chunk_index. This is appropriate for document-level retrieval quality gating on a corpus where each document covers a coherent topic.",
+  "k": 5,
+  "sample_count": 10,
+  "aggregates": {
+    "ndcg": {
+      "mean": 0.941,
+      "min": 0.6934,
+      "max": 1.0,
+      "count": 10
+    },
+    "mrr": {
+      "mean": 0.95,
+      "min": 0.5,
+      "max": 1.0,
+      "count": 10
+    },
+    "precision": {
+      "mean": 0.74,
+      "min": 0.2,
+      "max": 1.0,
+      "count": 10
+    },
+    "recall": {
+      "mean": 2.35,
+      "min": 1.0,
+      "max": 5.0,
+      "count": 10
+    }
+  },
+  "per_query": [
+    {
+      "id": "p3-01",
+      "query": "How does the A2A protocol compare between BeeAI framework and Agentopia implementations?",
+      "scenario": "factual_comparison",
+      "relevances": [
+        2.0,
+        2.0,
+        2.0,
+        2.0,
+        2.0
+      ],
+      "metrics": {
+        "ndcg": 1.0,
+        "mrr": 1.0,
+        "precision": 1.0,
+        "recall": 2.5
+      },
+      "detail": [
+        {
+          "rank": 1,
+          "document_id": "architecture/a2a-comparison.md",
+          "section": "A2A Implementation Comparison: BeeAI Framework vs Agentopia",
+          "chunk_index": 1,
+          "score": 0.8646,
+          "relevance_grade": 2,
+          "text_preview": "# A2A Implementation Comparison: BeeAI Framework vs Agentopia\n\n> Date: 2026-03-1"
+        },
+        {
+          "rank": 2,
+          "document_id": "architecture/a2a-comparison.md",
+          "section": "",
+          "chunk_index": 0,
+          "score": 0.8528,
+          "relevance_grade": 2,
+          "text_preview": "---\ntitle: \"A2A Implementation Comparison: BeeAI Framework vs Agentopia\"\n---"
+        },
+        {
+          "rank": 3,
+          "document_id": "architecture/a2a-comparison.md",
+          "section": "1. Overview",
+          "chunk_index": 2,
+          "score": 0.7863,
+          "relevance_grade": 2,
+          "text_preview": "## 1. Overview\n\nBoth projects implement the A2A protocol using the official Linu"
+        },
+        {
+          "rank": 4,
+          "document_id": "architecture/a2a-comparison.md",
+          "section": "11. Conclusion",
+          "chunk_index": 32,
+          "score": 0.7423,
+          "relevance_grade": 2,
+          "text_preview": "## 11. Conclusion\n\n**BeeAI strengths in A2A:**\n- gRPC transport for high-perform"
+        },
+        {
+          "rank": 5,
+          "document_id": "architecture/a2a-comparison.md",
+          "section": "2.3 Transport Protocols",
+          "chunk_index": 6,
+          "score": 0.7132,
+          "relevance_grade": 2,
+          "text_preview": "### 2.3 Transport Protocols\n\n| Transport | BeeAI | Agentopia |\n|---|---|---|\n| J"
+        }
+      ],
+      "total_relevant": 2
+    },
+    {
+      "id": "p3-02",
+      "query": "How does the multi-bot memory architecture work with shared knowledge and isolated identities?",
+      "scenario": "architecture_explanation",
+      "relevances": [
+        2.0,
+        1.0,
+        2.0,
+        2.0,
+        2.0
+      ],
+      "metrics": {
+        "ndcg": 0.9557,
+        "mrr": 1.0,
+        "precision": 1.0,
+        "recall": 2.5
+      },
+      "detail": [
+        {
+          "rank": 1,
+          "document_id": "architecture/architecture-multiple-bot.md",
+          "section": "Memory Architecture",
+          "chunk_index": 2,
+          "score": 0.7059,
+          "relevance_grade": 2,
+          "text_preview": "## Memory Architecture\n\nAgentopia uses a three-layer memory model that balances "
+        },
+        {
+          "rank": 2,
+          "document_id": "architecture/chatbot-architecture.md",
+          "section": "Memory Architecture",
+          "chunk_index": 6,
+          "score": 0.6693,
+          "relevance_grade": 1,
+          "text_preview": "## Memory Architecture\n\nAgentopia uses a three-layer memory system to give bots "
+        },
+        {
+          "rank": 3,
+          "document_id": "architecture/architecture-multiple-bot.md",
+          "section": "Bot Isolation and Sharing",
+          "chunk_index": 8,
+          "score": 0.6664,
+          "relevance_grade": 2,
+          "text_preview": "## Bot Isolation and Sharing\n\nEach bot operates in its own workspace with its ow"
+        },
+        {
+          "rank": 4,
+          "document_id": "architecture/architecture-multiple-bot.md",
+          "section": "",
+          "chunk_index": 0,
+          "score": 0.6657,
+          "relevance_grade": 2,
+          "text_preview": "---\ntitle: \"Multi-Bot Architecture\"\ndescription: \"How Agentopia orchestrates mul"
+        },
+        {
+          "rank": 5,
+          "document_id": "architecture/architecture-multiple-bot.md",
+          "section": "Layer 2 -- Knowledge (shared, persistent)",
+          "chunk_index": 4,
+          "score": 0.6114,
+          "relevance_grade": 2,
+          "text_preview": "### Layer 2 -- Knowledge (shared, persistent)\n\nAll bots share a common knowledge"
+        }
+      ],
+      "total_relevant": 2
+    },
+    {
+      "id": "p3-03",
+      "query": "What retrieval strategy was chosen for the Super RAG system and what alternatives were considered?",
+      "scenario": "design_decision",
+      "relevances": [
+        2.0,
+        2.0,
+        2.0,
+        2.0,
+        2.0
+      ],
+      "metrics": {
+        "ndcg": 1.0,
+        "mrr": 1.0,
+        "precision": 1.0,
+        "recall": 2.5
+      },
+      "detail": [
+        {
+          "rank": 1,
+          "document_id": "architecture/super-rag-blueprint.md",
+          "section": "1.5 RAG System \u2014 Retrieval Strategy",
+          "chunk_index": 7,
+          "score": 0.6313,
+          "relevance_grade": 2,
+          "text_preview": "### 1.5 RAG System \u2014 Retrieval Strategy\n\n| Blueprint Requirement | Current State"
+        },
+        {
+          "rank": 2,
+          "document_id": "architecture/super-rag-debate.md",
+          "section": "G. Decision Summary",
+          "chunk_index": 35,
+          "score": 0.5639,
+          "relevance_grade": 2,
+          "text_preview": "## G. Decision Summary\n\n| Decision | Verdict | Evidence Type |\n|---|---|---|\n| P"
+        },
+        {
+          "rank": 3,
+          "document_id": "architecture/super-rag-debate.md",
+          "section": "H1. Industry Standard Pipeline",
+          "chunk_index": 37,
+          "score": 0.5415,
+          "relevance_grade": 2,
+          "text_preview": "### H1. Industry Standard Pipeline\n\nProduction RAG has converged on three stages"
+        },
+        {
+          "rank": 4,
+          "document_id": "architecture/super-rag-blueprint.md",
+          "section": "6. Decision Points for CTO",
+          "chunk_index": 26,
+          "score": 0.5306,
+          "relevance_grade": 2,
+          "text_preview": "## 6. Decision Points for CTO\n\n1. **Phase 1 scope**: How many golden query-answe"
+        },
+        {
+          "rank": 5,
+          "document_id": "architecture/super-rag-debate.md",
+          "section": "Explicit Deferrals",
+          "chunk_index": 20,
+          "score": 0.5263,
+          "relevance_grade": 2,
+          "text_preview": "### Explicit Deferrals\n\n| Item | Reason | Revisit When |\n|---|---|---|\n| **Graph"
+        }
+      ],
+      "total_relevant": 2
+    },
+    {
+      "id": "p3-04",
+      "query": "How does the automated code review workflow enforce quality gates on pull requests?",
+      "scenario": "process_explanation",
+      "relevances": [
+        2.0,
+        0.0,
+        2.0,
+        1.0,
+        1.0
+      ],
+      "metrics": {
+        "ndcg": 0.9106,
+        "mrr": 1.0,
+        "precision": 0.8,
+        "recall": 2.0
+      },
+      "detail": [
+        {
+          "rank": 1,
+          "document_id": "architecture/governed-pr-review-workflow.md",
+          "section": "",
+          "chunk_index": 0,
+          "score": 0.6247,
+          "relevance_grade": 2,
+          "text_preview": "---\ntitle: \"Automated Code Review Workflow\"\ndescription: \"How Agentopia's bot-ba"
+        },
+        {
+          "rank": 2,
+          "document_id": "architecture/overview.md",
+          "section": "Reviewer",
+          "chunk_index": 11,
+          "score": 0.5694,
+          "relevance_grade": 0,
+          "text_preview": "### Reviewer\nInspects code quality. Can review pull requests, submit structured "
+        },
+        {
+          "rank": 3,
+          "document_id": "architecture/governed-pr-review-workflow.md",
+          "section": "How It Works",
+          "chunk_index": 1,
+          "score": 0.5691,
+          "relevance_grade": 2,
+          "text_preview": "## How It Works\n\nWhen a pull request is opened or updated, the platform receives"
+        },
+        {
+          "rank": 4,
+          "document_id": "architecture/reviewer-remediation.md",
+          "section": "What Works",
+          "chunk_index": 27,
+          "score": 0.5607,
+          "relevance_grade": 1,
+          "text_preview": "### What Works\n\n- Bot reliably posts GitHub reviews (APPROVE / REQUEST_CHANGES)\n"
+        },
+        {
+          "rank": 5,
+          "document_id": "architecture/reviewer-remediation.md",
+          "section": "Overview",
+          "chunk_index": 2,
+          "score": 0.5336,
+          "relevance_grade": 1,
+          "text_preview": "## Overview\n\nThe governed PR review workflow extends beyond finding-only review "
+        }
+      ],
+      "total_relevant": 2
+    },
+    {
+      "id": "p3-05",
+      "query": "What is the dual-lane interaction model in the Agentopia platform architecture?",
+      "scenario": "architecture_concept",
+      "relevances": [
+        2.0,
+        0.0,
+        0.0,
+        0.0,
+        0.0
+      ],
+      "metrics": {
+        "ndcg": 1.0,
+        "mrr": 1.0,
+        "precision": 0.2,
+        "recall": 1.0
+      },
+      "detail": [
+        {
+          "rank": 1,
+          "document_id": "architecture/overview.md",
+          "section": "Dual-Lane Interaction Model",
+          "chunk_index": 2,
+          "score": 0.7237,
+          "relevance_grade": 2,
+          "text_preview": "## Dual-Lane Interaction Model\n\nThe platform supports two distinct interaction m"
+        },
+        {
+          "rank": 2,
+          "document_id": "architecture/p1-execution-authorization.md",
+          "section": "Dual-Lane Model",
+          "chunk_index": 6,
+          "score": 0.5862,
+          "relevance_grade": 0,
+          "text_preview": "## Dual-Lane Model\n\nThe system operates in two semantic lanes:\n\n**Lane A -- Cons"
+        },
+        {
+          "rank": 3,
+          "document_id": "architecture/architecture-multiple-bot.md",
+          "section": "Memory Architecture",
+          "chunk_index": 2,
+          "score": 0.5668,
+          "relevance_grade": 0,
+          "text_preview": "## Memory Architecture\n\nAgentopia uses a three-layer memory model that balances "
+        },
+        {
+          "rank": 4,
+          "document_id": "architecture/a2a-full-design.md",
+          "section": "",
+          "chunk_index": 0,
+          "score": 0.5645,
+          "relevance_grade": 0,
+          "text_preview": "---\ntitle: \"Agent-to-Agent Protocol\"\ndescription: \"How Agentopia agents discover"
+        },
+        {
+          "rank": 5,
+          "document_id": "architecture/architecture-multiple-bot.md",
+          "section": "",
+          "chunk_index": 0,
+          "score": 0.5618,
+          "relevance_grade": 0,
+          "text_preview": "---\ntitle: \"Multi-Bot Architecture\"\ndescription: \"How Agentopia orchestrates mul"
+        }
+      ],
+      "total_relevant": 1
+    },
+    {
+      "id": "p3-06",
+      "query": "How does the deterministic delivery pipeline start and execute tasks?",
+      "scenario": "process_explanation",
+      "relevances": [
+        0.0,
+        2.0,
+        2.0,
+        0.0,
+        0.0
+      ],
+      "metrics": {
+        "ndcg": 0.6934,
+        "mrr": 0.5,
+        "precision": 0.4,
+        "recall": 2.0
+      },
+      "detail": [
+        {
+          "rank": 1,
+          "document_id": "architecture/overview.md",
+          "section": "Delivery Lifecycle",
+          "chunk_index": 6,
+          "score": 0.5281,
+          "relevance_grade": 0,
+          "text_preview": "## Delivery Lifecycle\n\nWhen an operator submits a delivery objective, the platfo"
+        },
+        {
+          "rank": 2,
+          "document_id": "architecture/p0.5-deterministic-delivery-start.md",
+          "section": "",
+          "chunk_index": 0,
+          "score": 0.5116,
+          "relevance_grade": 2,
+          "text_preview": "---\ntitle: \"Deterministic Delivery Start Front Door\"\n---"
+        },
+        {
+          "rank": 3,
+          "document_id": "architecture/p0.5-deterministic-delivery-start.md",
+          "section": "1. Problem Statement",
+          "chunk_index": 2,
+          "score": 0.4958,
+          "relevance_grade": 2,
+          "text_preview": "## 1. Problem Statement\n\nThere is an upstream gap before workflow start that P1 "
+        },
+        {
+          "rank": 4,
+          "document_id": "architecture/a2a-solution-protocol.md",
+          "section": "7. Autonomous Delivery Lifecycle",
+          "chunk_index": 15,
+          "score": 0.4948,
+          "relevance_grade": 0,
+          "text_preview": "## 7. Autonomous Delivery Lifecycle\n\n```mermaid\nsequenceDiagram\n    participant "
+        },
+        {
+          "rank": 5,
+          "document_id": "architecture/overview.md",
+          "section": "Execution Boundaries",
+          "chunk_index": 5,
+          "score": 0.4699,
+          "relevance_grade": 0,
+          "text_preview": "## Execution Boundaries\n\nThree boundaries ensure that code-modifying operations "
+        }
+      ],
+      "total_relevant": 1
+    },
+    {
+      "id": "p3-07",
+      "query": "What are the implementation phases for the production-ready A2A solution protocol?",
+      "scenario": "planning_detail",
+      "relevances": [
+        2.0,
+        2.0,
+        2.0,
+        2.0,
+        2.0
+      ],
+      "metrics": {
+        "ndcg": 1.0,
+        "mrr": 1.0,
+        "precision": 1.0,
+        "recall": 2.5
+      },
+      "detail": [
+        {
+          "rank": 1,
+          "document_id": "architecture/a2a-improvement-plan.md",
+          "section": "A2A Improvement Plan: Production-Ready A2A-First Architecture",
+          "chunk_index": 1,
+          "score": 0.7276,
+          "relevance_grade": 2,
+          "text_preview": "# A2A Improvement Plan: Production-Ready A2A-First Architecture\n\n> **Status**: P"
+        },
+        {
+          "rank": 2,
+          "document_id": "architecture/a2a-improvement-plan.md",
+          "section": "1. Problem Statement",
+          "chunk_index": 2,
+          "score": 0.6365,
+          "relevance_grade": 2,
+          "text_preview": "## 1. Problem Statement\n\nThe A2A implementation is now **A2A-first** with produc"
+        },
+        {
+          "rank": 3,
+          "document_id": "architecture/a2a-improvement-plan.md",
+          "section": "",
+          "chunk_index": 0,
+          "score": 0.6238,
+          "relevance_grade": 2,
+          "text_preview": "---\ntitle: \"A2A Improvement Plan: Production-Ready A2A-First Architecture\"\n---"
+        },
+        {
+          "rank": 4,
+          "document_id": "architecture/a2a-improvement-plan.md",
+          "section": "Phase 2 (production hardening) \u2014 ALL DONE",
+          "chunk_index": 25,
+          "score": 0.5927,
+          "relevance_grade": 2,
+          "text_preview": "### Phase 2 (production hardening) \u2014 ALL DONE\n\n```\nStep 2.1  a2a_protocol/task_s"
+        },
+        {
+          "rank": 5,
+          "document_id": "architecture/a2a-improvement-plan.md",
+          "section": "3. Phase 1: A2A-First Transport",
+          "chunk_index": 4,
+          "score": 0.5469,
+          "relevance_grade": 2,
+          "text_preview": "## 3. Phase 1: A2A-First Transport"
+        }
+      ],
+      "total_relevant": 2
+    },
+    {
+      "id": "p3-08",
+      "query": "How does the worker pool handle routing improvements for task distribution?",
+      "scenario": "architecture_detail",
+      "relevances": [
+        2.0,
+        2.0,
+        2.0,
+        2.0,
+        2.0
+      ],
+      "metrics": {
+        "ndcg": 1.0,
+        "mrr": 1.0,
+        "precision": 1.0,
+        "recall": 5.0
+      },
+      "detail": [
+        {
+          "rank": 1,
+          "document_id": "architecture/worker-pool-routing-improvement-plan.md",
+          "section": "",
+          "chunk_index": 0,
+          "score": 0.6484,
+          "relevance_grade": 2,
+          "text_preview": "---\ntitle: \"Worker Pool Routing Improvement Plan\"\n---\n\n\n**Status**: Improvement "
+        },
+        {
+          "rank": 2,
+          "document_id": "architecture/worker-pool-routing-improvement-plan.md",
+          "section": "Less ambiguity in multi-worker teams",
+          "chunk_index": 12,
+          "score": 0.5735,
+          "relevance_grade": 2,
+          "text_preview": "### Less ambiguity in multi-worker teams\n\nWithout capability-aware routing, oper"
+        },
+        {
+          "rank": 3,
+          "document_id": "architecture/worker-pool-routing-improvement-plan.md",
+          "section": "Phase 3 \u2014 Eligible-subset routing",
+          "chunk_index": 19,
+          "score": 0.5603,
+          "relevance_grade": 2,
+          "text_preview": "### Phase 3 \u2014 Eligible-subset routing\n\nConnect packet classification to worker c"
+        },
+        {
+          "rank": 4,
+          "document_id": "architecture/worker-pool-routing-improvement-plan.md",
+          "section": "8. Success Criteria",
+          "chunk_index": 23,
+          "score": 0.5276,
+          "relevance_grade": 2,
+          "text_preview": "## 8. Success Criteria\n\nThe routing improvement plan is successful when:\n\n- Fron"
+        },
+        {
+          "rank": 5,
+          "document_id": "architecture/worker-pool-routing-improvement-plan.md",
+          "section": "5. Design Principles",
+          "chunk_index": 15,
+          "score": 0.5146,
+          "relevance_grade": 2,
+          "text_preview": "## 5. Design Principles\n\n1. **Explicit capability modeling.** Worker capabilitie"
+        }
+      ],
+      "total_relevant": 1
+    },
+    {
+      "id": "p3-09",
+      "query": "How are conflicts resolved when multiple review systems coexist in the codebase?",
+      "scenario": "process_explanation",
+      "relevances": [
+        2.0,
+        2.0,
+        2.0,
+        0.0,
+        0.0
+      ],
+      "metrics": {
+        "ndcg": 1.0,
+        "mrr": 1.0,
+        "precision": 0.6,
+        "recall": 1.5
+      },
+      "detail": [
+        {
+          "rank": 1,
+          "document_id": "architecture/reviewer-coexistence.md",
+          "section": "Reviewer Coexistence Model",
+          "chunk_index": 1,
+          "score": 0.5596,
+          "relevance_grade": 2,
+          "text_preview": "# Reviewer Coexistence Model\n\n> How Agentopia separates workflow reviewers from "
+        },
+        {
+          "rank": 2,
+          "document_id": "architecture/reviewer-coexistence.md",
+          "section": "",
+          "chunk_index": 0,
+          "score": 0.5344,
+          "relevance_grade": 2,
+          "text_preview": "---\ntitle: \"Reviewer Coexistence Model\"\n---"
+        },
+        {
+          "rank": 3,
+          "document_id": "architecture/reviewer-coexistence.md",
+          "section": "3. Coexistence Guarantee",
+          "chunk_index": 9,
+          "score": 0.5339,
+          "relevance_grade": 2,
+          "text_preview": "## 3. Coexistence Guarantee\n\nWhen both reviewer types are active:\n\n```\nRoleRegis"
+        },
+        {
+          "rank": 4,
+          "document_id": "architecture/governed-pr-review-workflow.md",
+          "section": "Architecture Summary",
+          "chunk_index": 7,
+          "score": 0.5103,
+          "relevance_grade": 0,
+          "text_preview": "## Architecture Summary\n\nThe workflow separates concerns into two planes:\n\n**Pla"
+        },
+        {
+          "rank": 5,
+          "document_id": "architecture/governed-pr-review-workflow.md",
+          "section": "Reviewer Bot",
+          "chunk_index": 2,
+          "score": 0.5035,
+          "relevance_grade": 0,
+          "text_preview": "## Reviewer Bot\n\nThe reviewer bot is the execution actor. It receives a structur"
+        }
+      ],
+      "total_relevant": 2
+    },
+    {
+      "id": "p3-10",
+      "query": "What are the execution authorization requirements and gate criteria for P1?",
+      "scenario": "gate_criteria",
+      "relevances": [
+        2.0,
+        0.0,
+        0.0,
+        0.0,
+        2.0
+      ],
+      "metrics": {
+        "ndcg": 0.8503,
+        "mrr": 1.0,
+        "precision": 0.4,
+        "recall": 2.0
+      },
+      "detail": [
+        {
+          "rank": 1,
+          "document_id": "architecture/p1-execution-authorization.md",
+          "section": "",
+          "chunk_index": 0,
+          "score": 0.4733,
+          "relevance_grade": 2,
+          "text_preview": "---\ntitle: \"Execution Authorization\"\ndescription: \"Dual-lane security model that"
+        },
+        {
+          "rank": 2,
+          "document_id": "architecture/super-rag-debate.md",
+          "section": "5. Minimum production-ready eval gate?",
+          "chunk_index": 33,
+          "score": 0.4733,
+          "relevance_grade": 0,
+          "text_preview": "### 5. Minimum production-ready eval gate?\n\n**Phase 1a** (RAGAS directional sign"
+        },
+        {
+          "rank": 3,
+          "document_id": "architecture/p0.5-deterministic-delivery-start.md",
+          "section": "7. Relationship To P1",
+          "chunk_index": 13,
+          "score": 0.4732,
+          "relevance_grade": 0,
+          "text_preview": "## 7. Relationship To P1\n\n| Milestone | Scope | Dependency |\n|---|---|---|\n| **P"
+        },
+        {
+          "rank": 4,
+          "document_id": "architecture/p0.5-deterministic-delivery-start.md",
+          "section": "Deterministic Delivery Start Front Door",
+          "chunk_index": 1,
+          "score": 0.4545,
+          "relevance_grade": 0,
+          "text_preview": "# Deterministic Delivery Start Front Door\n\n> Status: CLOSED/DEFERRED \u2014 C2 reject"
+        },
+        {
+          "rank": 5,
+          "document_id": "architecture/p1-execution-authorization.md",
+          "section": "Authorization Matrix",
+          "chunk_index": 4,
+          "score": 0.4452,
+          "relevance_grade": 2,
+          "text_preview": "## Authorization Matrix\n\n| Action Class | Execution Class Required | Role Requir"
+        }
+      ],
+      "total_relevant": 1
+    }
+  ],
+  "gate": {
+    "threshold": 0.9,
+    "baseline_reference": 0.925,
+    "ndcg_mean": 0.941,
+    "passed": true
+  }
+}


### PR DESCRIPTION
## Summary

P3.6 retrieval evaluation gate on live chunked pilot scope `utop/oddspark`.

- 10 queries grounded in the real architecture corpus (16 documents, 417 chunks)
- Document-level relevance grading (scale 0-2)
- Direct Qdrant vector search using same embedding model as pipeline
- nDCG@5 = **0.9410** — above both 0.90 hard floor and 0.925 P0.1 baseline

## Artifacts

| File | Purpose |
|------|---------|
| `src/eval/datasets/p3_pilot_gate.json` | Query set + relevance judgments |
| `src/eval/p3_pilot_gate.py` | Eval runner (queries Qdrant directly) |
| `src/eval/results/nDCG-p3-pilot-gate.json` | Full results with per-query breakdown |

## Closes

Closes #10