### PR TITLE
feat(ingest): Phase 3 source-aware Pathway runtime (ADR-001)

### DIFF
--- a/src/ingest/pipeline.py
+++ b/src/ingest/pipeline.py
@@ -1,28 +1,54 @@
-"""Pathway ingest pipeline — agentopia-rag-platform Phase 3.
+"""Pathway ingest pipeline — agentopia-rag-platform.
 
-Entry point for the differential dataflow ingest pipeline.
-Reads documents from S3, chunks + embeds them, and upserts into Qdrant.
+Phase 3 (ADR-001): the runtime is source-aware. At startup we read every
+active `managed_upload` row from the control-plane `knowledge_sources`
+table and materialise one Pathway watcher per source, each sinking into
+its own scope-derived Qdrant collection (`kb-{sha256(scope)[:16]}`).
 
-All configuration is via environment variables (set from K8s Secrets):
-  QDRANT_URL           — e.g. http://qdrant:6333
-  QDRANT_COLLECTION    — target collection name, e.g. kb-<scope_hash>
-  SCOPE_IDENTITY       — human-readable scope, e.g. utop/oddspark (default: QDRANT_COLLECTION)
-  S3_BUCKET_NAME       — source S3 bucket
-  S3_PREFIX            — object prefix to poll, e.g. scopes/{scope}/
-  S3_REGION            — AWS region
-  S3_ACCESS_KEY        — AWS access key ID (from K8s Secret)
-  S3_SECRET_ACCESS_KEY — AWS secret access key (from K8s Secret)
-  EMBEDDING_BASE_URL   — OpenAI-compatible base URL (e.g. https://api.openai.com/v1)
-  EMBEDDING_API_KEY    — API key for the embedding endpoint
-  EMBEDDING_MODEL      — model name, default text-embedding-3-small
-  PATHWAY_POLL_INTERVAL_SECS — S3 poll interval in seconds, default 30
-  PATHWAY_STATE_DIR    — path for persistence state PVC, default /var/pathway/state
+Backward-compatibility envelope during the Phase 3/4 window:
+
+  * The old single-prefix env contract (`S3_BUCKET_NAME`, `S3_PREFIX`,
+    `S3_REGION`, `SCOPE_IDENTITY`, `QDRANT_COLLECTION`) still bootstraps
+    a synthetic pilot source when `knowledge_sources` has no rows — see
+    `source_registry.synthesize_pilot_source`. New deployments should
+    stop relying on it once a row is backfilled, per Phase 1.
+  * Qdrant payload still carries the same fields as before (`scope`,
+    `document_id`, `section_path`, ...). We additionally write
+    `source_id` on every new chunk. Existing chunks without `source_id`
+    stay queryable — retrieval filters on `scope`, which continues to
+    work for both shapes.
+  * `document_id` stays the raw S3 key (e.g. `architecture/foo.md`).
+    Changing it now would invalidate every current Qdrant point's
+    identity and force a global reindex. A canonical source-aware
+    `document_id` is a future-phase concern once the corpus is entirely
+    new-shape.
+
+Per-source env vars (still read, now optional):
+    QDRANT_URL                — Qdrant endpoint (shared by all watchers)
+    EMBEDDING_BASE_URL        — OpenAI-compatible embeddings endpoint
+    EMBEDDING_API_KEY         — API key for the embedding endpoint
+    EMBEDDING_MODEL           — default text-embedding-3-small
+    S3_ACCESS_KEY             — AWS creds, shared across managed sources
+    S3_SECRET_ACCESS_KEY
+    PATHWAY_POLL_INTERVAL_SECS — S3 poll interval in seconds, default 30
+    PATHWAY_STATE_DIR         — path for persistence state PVC
+
+Registry connectivity env (new in Phase 3):
+    DATABASE_URL              — Postgres DSN; when unset, the runtime
+                                falls back to the synthetic pilot
+                                source built from the env vars below
+                                (preserves local dev + bootstrap).
+
+Per-source fields live on the `knowledge_sources` row; Phase 3 reads
+them directly via `source_registry.resolve_sources()` — the old single-
+prefix env vars drive only the synthetic-fallback path.
 """
 
 import hashlib
 import json
+import logging
 import os
-import re
+import sys
 import time as _time
 
 import pathway as pw
@@ -32,18 +58,23 @@ from qdrant_client.models import Distance, PointStruct, VectorParams
 
 from dotenv import load_dotenv
 
+from ingest.source_registry import SourceConfig, log_source_plan, resolve_sources
+
 load_dotenv()
 
+logging.basicConfig(
+    level=os.environ.get("LOG_LEVEL", "INFO"),
+    format="%(asctime)s [%(levelname)s] %(name)s - %(message)s",
+)
+logger = logging.getLogger("pipeline")
+
+
 # ---------------------------------------------------------------------------
-# Configuration
+# Shared configuration (non-source)
 # ---------------------------------------------------------------------------
 
 QDRANT_URL = os.environ["QDRANT_URL"]
-QDRANT_COLLECTION = os.environ["QDRANT_COLLECTION"]
 
-S3_BUCKET = os.environ["S3_BUCKET_NAME"]
-S3_PREFIX = os.environ.get("S3_PREFIX", "")
-S3_REGION = os.environ.get("S3_REGION", "us-east-1")
 S3_ACCESS_KEY = os.environ["S3_ACCESS_KEY"]
 S3_SECRET_KEY = os.environ["S3_SECRET_ACCESS_KEY"]
 
@@ -53,66 +84,38 @@ EMBEDDING_MODEL = os.environ.get("EMBEDDING_MODEL", "text-embedding-3-small")
 
 POLL_INTERVAL = int(os.environ.get("PATHWAY_POLL_INTERVAL_SECS", "30"))
 STATE_DIR = os.environ.get("PATHWAY_STATE_DIR", "/var/pathway/state")
-# Human-readable scope identity stored in Qdrant payload (e.g. "utop/oddspark").
-# Defaults to QDRANT_COLLECTION (collection hash) if not explicitly set.
-# Set SCOPE_IDENTITY to the source scope for correct gateway retrieval filtering.
-SCOPE_IDENTITY = os.environ.get("SCOPE_IDENTITY", QDRANT_COLLECTION)
 
-VECTOR_DIM = 1536  # text-embedding-3-small output dimension
-# text-embedding-3-small max input: 8191 tokens (~4 chars/token).
-# Safety-net truncation guard — normal operation should not hit this after chunking.
-_MAX_EMBED_CHARS = 30_000  # ≈ 7500 tokens — fallback ceiling if a chunk is unexpectedly large
-
-# Chunking parameters.
-# Primary split: markdown H1/H2/H3 headers (detected outside fenced code blocks).
-# Fallback: bounded windows with overlap for sections exceeding _CHUNK_MAX_CHARS.
-_CHUNK_MAX_CHARS = 8_000   # ≈ 2000 tokens — ceiling per chunk, well under embedding limit
-_CHUNK_OVERLAP_CHARS = 200  # overlap between window sub-chunks for context continuity
+VECTOR_DIM = 1536
+_MAX_EMBED_CHARS = 30_000
+_CHUNK_MAX_CHARS = 8_000
+_CHUNK_OVERLAP_CHARS = 200
 
 _openai_client = OpenAI(api_key=EMBEDDING_API_KEY, base_url=EMBEDDING_BASE_URL)
 
+
 # ---------------------------------------------------------------------------
-# Markdown chunking
+# Markdown chunking  (unchanged from Phase 0 — still deterministic per doc)
 # ---------------------------------------------------------------------------
 
 def _chunk_markdown(text: str) -> list:
     """Split a markdown document into sub-document chunks.
 
-    Primary strategy: split at H1 / H2 / H3 header boundaries so each
-    section becomes its own chunk.  This preserves semantic coherence for
-    structured markdown documents (the corpus standard for utop/oddspark).
-
-    Headers are detected line-by-line with fenced code block tracking so
-    that Python/shell comment lines inside code blocks (e.g. "# variable")
-    are never mistaken for markdown headers.
-
-    Fallback: when a section exceeds _CHUNK_MAX_CHARS (e.g. a dense code
-    block or very long prose section), the section is subdivided into
-    overlapping fixed-size windows using _CHUNK_OVERLAP_CHARS of overlap
-    to maintain context continuity across the boundary.
-
-    Each returned dict has:
-      text         — chunk text (includes the header line when split at header)
-      section      — header title string (stripped of leading '#'), or "" for
-                     preamble text before the first header
-      chunk_index  — 0-based index of this chunk within the document
-      total_chunks — total number of chunks for this document
+    Primary: header boundaries (H1/H2/H3 outside fenced code blocks).
+    Fallback: overlapping fixed-size windows when a section exceeds the
+    per-chunk ceiling.
     """
+    import re as _re
+
     if not isinstance(text, str):
-        # S3 plaintext_by_object delivers str; guard against unexpected bytes.
         try:
             text = text.decode("utf-8", errors="replace")
         except AttributeError:
             text = str(text)
 
-    # Scan line-by-line, tracking fenced code blocks.
-    # Headers (H1-H3) are only matched outside fences so that comment lines
-    # inside code blocks (e.g. "# python_var", "# shell comment") are ignored.
     in_fence = False
     fence_marker = ""
-    header_positions: list = []  # [(char_offset, title), ...]
+    header_positions: list = []
     pos = 0
-
     for line in text.splitlines(keepends=True):
         stripped = line.lstrip()
         if not in_fence:
@@ -120,7 +123,7 @@ def _chunk_markdown(text: str) -> list:
                 in_fence = True
                 fence_marker = stripped[:3]
             else:
-                m = re.match(r'^(#{1,3}) (.+)', line)
+                m = _re.match(r'^(#{1,3}) (.+)', line)
                 if m:
                     header_positions.append((pos, m.group(2).strip()))
         else:
@@ -128,13 +131,10 @@ def _chunk_markdown(text: str) -> list:
                 in_fence = False
         pos += len(line)
 
-    # Build (section_title, section_text) pairs from detected header positions
     sections: list = []
     if not header_positions:
-        # No headers — treat the entire document as a single unnamed section.
         sections = [("", text)]
     else:
-        # Preamble before the first header
         if header_positions[0][0] > 0:
             preamble = text[:header_positions[0][0]].strip()
             if preamble:
@@ -145,7 +145,6 @@ def _chunk_markdown(text: str) -> list:
             if section_text:
                 sections.append((title, section_text))
 
-    # Sub-split any section that exceeds the per-chunk ceiling
     chunks: list = []
     for section_title, section_text in sections:
         if len(section_text) <= _CHUNK_MAX_CHARS:
@@ -162,21 +161,17 @@ def _chunk_markdown(text: str) -> list:
                 start = next_start
 
     if not chunks:
-        # Absolute fallback: emit a single chunk with truncated content.
         chunks = [{"section": "", "text": text[:_CHUNK_MAX_CHARS]}]
 
-    # Annotate with positional metadata
     total = len(chunks)
     for i, chunk in enumerate(chunks):
         chunk["chunk_index"] = i
         chunk["total_chunks"] = total
-
     return chunks
 
 
 @pw.udf
 def chunk_text(text: str) -> list:
-    """Pathway UDF: split one document into a list of chunk dicts."""
     if not isinstance(text, str):
         try:
             s = str(text)
@@ -188,23 +183,11 @@ def chunk_text(text: str) -> list:
 
 
 # ---------------------------------------------------------------------------
-# Embedding
+# Embedding UDF (unchanged)
 # ---------------------------------------------------------------------------
 
 @pw.udf
 def embed_chunk(chunk) -> list:
-    """Embed a single chunk dict (pw.Json from flatten output).
-
-    Receives one chunk dict per row after flatten().  The dict may arrive as
-    a plain Python dict (Pathway deserialises pw.Json for UDFs) or as a
-    pw.Json object — both forms are handled defensively.
-
-    After sub-document chunking, chunk sizes are well below _MAX_EMBED_CHARS
-    in normal operation.  The truncation guard remains as a safety net for
-    unexpectedly large sections or malformed input.
-    """
-    # Deserialise chunk dict — it arrives as Python dict when Pathway
-    # deserialises the pw.Json column, but handle raw pw.Json defensively.
     if isinstance(chunk, dict):
         text = str(chunk.get("text", ""))
     else:
@@ -222,24 +205,11 @@ def embed_chunk(chunk) -> list:
 
 
 # ---------------------------------------------------------------------------
-# JSON unwrapping helpers
+# JSON unwrapping helpers (unchanged)
 # ---------------------------------------------------------------------------
 
 def _unwrap_json(val: object) -> str:
-    """Unwrap a Pathway Json column value from its ConnectorObserver row form.
-
-    Pathway delivers pw.Json-typed columns (e.g. pw.this._metadata["path"]) as
-    one of three forms in on_change row dicts:
-      Form A — dict wrapper:  {"_value": '"path/to/file.md"'}
-      Form B — plain str:     '"path/to/file.md"'  (raw JSON text, Python str type)
-      Form C — pw.Json obj:   str(val) == '"path/to/file.md"'  (not a plain str/dict)
-
-    In all cases str(val) produces the JSON-encoded representation of the value,
-    so json.loads(str(val)) is the correct canonical decoder.  Form A is handled
-    via the dict branch for safety; Forms B and C fall through to json.loads.
-    """
     if isinstance(val, dict) and "_value" in val:
-        # Form A: unwrap the _value key, then json-decode to strip JSON encoding.
         inner = val["_value"]
         try:
             decoded = json.loads(inner) if isinstance(inner, str) else inner
@@ -248,9 +218,6 @@ def _unwrap_json(val: object) -> str:
             return str(inner) if inner is not None else ""
     if val is None:
         return ""
-    # Forms B and C: str() of the value is a JSON-encoded string.
-    # json.loads strips the surrounding double-quote characters produced by
-    # Pathway's JSON serialization of string values.
     s = str(val)
     try:
         decoded = json.loads(s)
@@ -262,12 +229,6 @@ def _unwrap_json(val: object) -> str:
 
 
 def _unwrap_chunk_dict(val: object) -> dict:
-    """Extract a Python dict from a pw.Json chunk column in on_change.
-
-    After flatten(), the chunk column (pw.Json) arrives in on_change as
-    either a plain Python dict (Pathway deserialises for ConnectorObserver)
-    or as a pw.Json object whose str() is a JSON-encoded dict.
-    """
     if isinstance(val, dict):
         return val
     if val is None:
@@ -280,27 +241,33 @@ def _unwrap_chunk_dict(val: object) -> dict:
 
 
 # ---------------------------------------------------------------------------
-# Qdrant sink
+# Qdrant sink — now source-aware
 # ---------------------------------------------------------------------------
 
 class QdrantSink(pw.io.python.ConnectorObserver):
-    """Upserts chunk embeddings into a Qdrant collection.
+    """Per-source Qdrant sink.
 
-    Each Qdrant point represents one sub-document chunk.  Pathway's
-    differential dataflow ensures correct retraction (deletion) semantics:
-    when a source document is deleted or updated, all chunk rows derived
-    from that document are retracted by Pathway, and on_change is called
-    with is_addition=False for each chunk — triggering the corresponding
-    Qdrant deletes automatically.
+    Phase-3 change: the sink is constructed with the source's identity
+    (`source_id`, `scope_identity`) and the derived Qdrant collection
+    name. Every chunk this sink writes carries `source_id` + `scope` in
+    its payload. Legacy chunks without `source_id` remain queryable —
+    they just don't participate in source-scoped filters.
 
-    Point identity is stable per (document, chunk_index): Pathway's flatten
-    operation assigns each chunk a compound row key (original_doc_key +
-    list_position), which _row_id maps to a stable 63-bit Qdrant point ID.
+    Differential dataflow semantics are preserved: `is_addition=False`
+    rows for retracted chunks delete the corresponding Qdrant points.
     """
 
-    def __init__(self, url: str, collection: str) -> None:
+    def __init__(
+        self,
+        url: str,
+        collection: str,
+        scope_identity: str,
+        source_id: str | None,
+    ) -> None:
         self._client = QdrantClient(url=url)
         self._collection = collection
+        self._scope_identity = scope_identity
+        self._source_id = source_id
         self._ensure_collection()
 
     def _ensure_collection(self) -> None:
@@ -312,8 +279,6 @@ class QdrantSink(pw.io.python.ConnectorObserver):
             )
 
     def _row_id(self, key: pw.Pointer) -> int:
-        # Pathway Pointer (compound after flatten: doc_key + chunk_index position)
-        # → stable 63-bit int suitable for Qdrant point ID.
         return int(hashlib.sha256(str(key).encode()).hexdigest(), 16) % (2**63)
 
     def on_change(
@@ -325,43 +290,36 @@ class QdrantSink(pw.io.python.ConnectorObserver):
     ) -> None:
         point_id = self._row_id(key)
         if is_addition:
-            # chunk column contains the full chunk dict (pw.Json).
-            # _unwrap_chunk_dict handles both Python-dict and pw.Json-object forms.
             chunk = _unwrap_chunk_dict(row.get("chunk"))
             chunk_text = str(chunk.get("text", ""))
             section = str(chunk.get("section", ""))
             chunk_index = int(chunk.get("chunk_index", 0))
             total_chunks = int(chunk.get("total_chunks", 1))
 
+            payload = {
+                "document_id": _unwrap_json(row.get("document_id")),
+                # Canonical scope identity for retrieval filters —
+                # unchanged from Phase 0 so legacy and Phase-3 chunks
+                # co-exist under the same filter.
+                "scope": self._scope_identity,
+                "section_path": _unwrap_json(row.get("section_path")),
+                "section": section,
+                "chunk_index": chunk_index,
+                "total_chunks": total_chunks,
+                "text": chunk_text,
+                "status": "active",
+                "document_hash": hashlib.sha256(chunk_text.encode()).hexdigest(),
+                "ingested_at": _time.time(),
+            }
+            # Phase-3 additive payload field: stable source identity.
+            # Synthetic pilot sources do not have a source_id; the field
+            # is omitted rather than faked so downstream code can tell.
+            if self._source_id:
+                payload["source_id"] = self._source_id
+
             self._client.upsert(
                 collection_name=self._collection,
-                points=[
-                    PointStruct(
-                        id=point_id,
-                        vector=row["embedding"],
-                        payload={
-                            "document_id": _unwrap_json(row.get("document_id")),
-                            "scope": SCOPE_IDENTITY,
-                            "section_path": _unwrap_json(row.get("section_path")),
-                            "section": section,
-                            "chunk_index": chunk_index,
-                            "total_chunks": total_chunks,
-                            "text": chunk_text,
-                            "status": "active",
-                            # document_hash: SHA-256 of this chunk's text — enables
-                            # chunk-level deduplication and change detection.
-                            "document_hash": hashlib.sha256(
-                                chunk_text.encode()
-                            ).hexdigest(),
-                            # ingested_at: wall-clock Unix timestamp (seconds) when this
-                            # chunk was written to Qdrant. Pathway's `time` parameter is a
-                            # logical batch epoch in ms (autocommit_duration_ms cycles) —
-                            # NOT wall-clock time. _time.time() is the correct source for
-                            # freshness lag measurement (P3.5).
-                            "ingested_at": _time.time(),
-                        },
-                    )
-                ],
+                points=[PointStruct(id=point_id, vector=row["embedding"], payload=payload)],
             )
         else:
             self._client.delete(
@@ -374,16 +332,31 @@ class QdrantSink(pw.io.python.ConnectorObserver):
 
 
 # ---------------------------------------------------------------------------
-# Pipeline
+# Per-source subgraph
 # ---------------------------------------------------------------------------
 
-def build_pipeline() -> None:
-    # -- Source: S3 polling connector ----------------------------------------
+def _build_source_subgraph(source: SourceConfig) -> None:
+    """Construct the ingest subgraph for one source.
+
+    Each source contributes an independent `pw.io.s3.read(...)` connector
+    plus the chunk/embed/sink chain; `pw.run()` evaluates all of them in
+    one process. Writing them as separate subgraphs — instead of one
+    unioned table — keeps Qdrant sink routing trivial (one sink per
+    source, one collection per scope).
+    """
+    logger.info(
+        "pipeline: building subgraph  source_id=%s  scope=%s  s3://%s/%s",
+        source.source_id or "synthetic-env",
+        source.scope_identity,
+        source.bucket,
+        source.prefix,
+    )
+
     documents = pw.io.s3.read(
-        S3_PREFIX,
+        source.prefix,
         aws_s3_settings=pw.io.s3.AwsS3Settings(
-            bucket_name=S3_BUCKET,
-            region=S3_REGION,
+            bucket_name=source.bucket,
+            region=source.region,
             access_key=S3_ACCESS_KEY,
             secret_access_key=S3_SECRET_KEY,
         ),
@@ -393,34 +366,12 @@ def build_pipeline() -> None:
         autocommit_duration_ms=POLL_INTERVAL * 1000,
     )
 
-    # -- Transform: derive document_id and section_path from S3 object key ----
-    # pw.this._metadata["path"] produces a pw.Json-typed column. When delivered
-    # to ConnectorObserver.on_change it arrives as {"_value": "s3/key.md"}.
-    # _unwrap_json() in on_change extracts the plain string from that wrapper.
     documents = documents.select(
         text=pw.this.data,
         document_id=pw.this._metadata["path"],
         section_path=pw.this._metadata["path"],
     )
 
-    # -- Transform: chunk each document into sub-document pieces --------------
-    # chunk_text() returns list[dict] (section, text, chunk_index, total_chunks).
-    # flatten() expands that list so each chunk becomes its own Pathway row.
-    # After flatten, pw.this.chunks is one chunk dict (pw.Json) per row.
-    #
-    # Row identity design:
-    # Pathway assigns compound row keys (original_doc_key + list_position) after
-    # flatten().  This means each chunk's Qdrant point ID is stable per
-    # (document, chunk_index).  When a source document is deleted or updated,
-    # Pathway retracts all derived chunk rows — QdrantSink.on_change receives
-    # is_addition=False for each chunk and deletes the corresponding point.
-    #
-    # Important: Pathway 0.30.0 does not support string-key indexing on pw.Json
-    # columns in select() expressions (only integer indexing on arrays).  To
-    # avoid this limitation, the full chunk dict is passed as a single column
-    # ("chunk") to the sink and embedded via embed_chunk().  Field extraction
-    # (section, chunk_index, total_chunks, text) happens inside the UDF and
-    # inside on_change(), where plain Python dict access is available.
     documents_with_chunks = documents.select(
         chunks=chunk_text(pw.this.text),
         document_id=pw.this.document_id,
@@ -429,9 +380,6 @@ def build_pipeline() -> None:
 
     chunk_rows = documents_with_chunks.flatten(pw.this.chunks)
 
-    # -- Transform: embed each chunk ------------------------------------------
-    # embed_chunk() receives the full chunk dict (pw.Json) and extracts the
-    # "text" field internally to avoid pw.Json string-key indexing in the graph.
     embedded = chunk_rows.select(
         chunk=pw.this.chunks,
         document_id=pw.this.document_id,
@@ -439,12 +387,47 @@ def build_pipeline() -> None:
         embedding=embed_chunk(pw.this.chunks),
     )
 
-    # -- Sink: Qdrant upsert --------------------------------------------------
-    pw.io.python.write(embedded, QdrantSink(url=QDRANT_URL, collection=QDRANT_COLLECTION))
+    pw.io.python.write(
+        embedded,
+        QdrantSink(
+            url=QDRANT_URL,
+            collection=source.qdrant_collection,
+            scope_identity=source.scope_identity,
+            source_id=source.source_id,
+        ),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Entry point
+# ---------------------------------------------------------------------------
+
+def build_pipeline(sources: list[SourceConfig] | None = None) -> int:
+    """Construct the Pathway dataflow graph.
+
+    Returns the number of source watchers materialised. The caller (or
+    the module main) fails fast when zero — trying to `pw.run()` with
+    no watchers is a silent no-op in Pathway.
+    """
+    if sources is None:
+        sources = resolve_sources()
+    log_source_plan(sources)
+    if not sources:
+        return 0
+    for source in sources:
+        _build_source_subgraph(source)
+    return len(sources)
 
 
 if __name__ == "__main__":
-    build_pipeline()
+    count = build_pipeline()
+    if count == 0:
+        logger.error(
+            "pipeline: no active managed_upload sources found and no pilot "
+            "env fallback is configured — refusing to start a zero-watcher "
+            "Pathway process (would silently do nothing)."
+        )
+        sys.exit(1)
 
     pw.run(
         persistence_config=pw.persistence.Config(

--- a/src/ingest/source_registry.py
+++ b/src/ingest/source_registry.py
@@ -1,0 +1,268 @@
+"""Source registry — the ingest runtime's read-only view onto bot-config-api's
+`knowledge_sources` table (ADR-001 Phase 3).
+
+Pathway needs to know which buckets/prefixes to watch, what scope each one
+feeds, and what Qdrant collection the chunks land in. Phase 1 introduced
+the `knowledge_sources` table; Phase 2 made the upload/status contract
+source-aware; Phase 3 brings the runtime in line by:
+
+    * Reading active `managed_upload` sources at pipeline startup.
+    * Materialising one Pathway watcher per source (see pipeline.py).
+    * Preserving the pilot's single-scope env-based bootstrap as a
+      fallback so local development and cluster rebuilds that run
+      before Postgres is reachable still work.
+
+Design choices:
+
+    * **Startup-only read.** Pathway constructs its dataflow graph at
+      process start; adding or removing a `pw.io.s3.read(...)` watcher
+      requires a process restart anyway. This keeps the runtime
+      predictable — no concurrent watcher lifecycle management, no
+      race with mid-flight S3 polls.
+    * **Skip-with-error, don't ingest wrong data.** A row with an
+      incomplete `storage_ref` is logged loudly and skipped. The
+      runtime never silently falls back to "some other bucket" for a
+      broken source row.
+    * **No DB writes.** This module is read-only. Source CRUD lives on
+      the bot-config-api control plane.
+
+Not yet in scope for Phase 3:
+
+    * `external_s3` kind (Phase 4).
+    * Per-source Vault credential fetch (Phase 4).
+    * Hot reload of the registry (Phase 3+).
+"""
+
+from __future__ import annotations
+
+import hashlib
+import logging
+import os
+from dataclasses import dataclass
+from typing import Iterable
+
+try:
+    import psycopg
+    from psycopg.rows import dict_row as _dict_row
+except ImportError:  # pragma: no cover — container image has psycopg
+    psycopg = None  # type: ignore[assignment]
+    _dict_row = None  # type: ignore[assignment]
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class SourceConfig:
+    """Everything the Pathway runtime needs to stand up a single watcher."""
+
+    source_id: str | None  # None for synthetic pilot-env fallbacks
+    scope_identity: str    # e.g. "utop/oddspark" — human-readable
+    bucket: str
+    prefix: str
+    region: str
+    qdrant_collection: str  # kb-{sha256(scope)[:16]}
+
+    @property
+    def is_synthetic(self) -> bool:
+        """True when this config came from env vars, not a DB row."""
+        return self.source_id is None
+
+
+def _qdrant_collection_for_scope(scope: str) -> str:
+    """Match the hashing bot-config-api / knowledge-api use (ADR-011).
+
+    Same algorithm used in:
+      - bot-config-api `routers/knowledge.py` (upload-status path)
+      - knowledge-api `services/knowledge.py` (`QdrantBackend._qdrant_collection_name`)
+      - agentopia-ui `KnowledgePage` does not compute this — it reads collection
+        name from the API responses.
+    Keeping the derivation in lock-step prevents split-brain at retrieval
+    time: the same canonical scope identity always maps to the same
+    collection, irrespective of which service produced the key.
+    """
+    return "kb-" + hashlib.sha256(scope.encode("utf-8")).hexdigest()[:16]
+
+
+def _db_url() -> str:
+    return os.getenv("DATABASE_URL", "")
+
+
+def _row_to_config(row: dict) -> SourceConfig | None:
+    """Project a `knowledge_sources` row onto a SourceConfig.
+
+    Returns None (and logs loudly) when the row is not a safe runtime
+    target — incomplete `storage_ref` fields, unsupported kind, or
+    non-active status. This is the "skip with error, don't ingest wrong
+    data" contract from the module docstring.
+    """
+    kind = str(row.get("kind") or "")
+    status = str(row.get("status") or "")
+    source_id = str(row.get("source_id") or "")
+    client_id = row.get("client_id") or ""
+    scope_name = row.get("scope_name") or ""
+    scope_identity = f"{client_id}/{scope_name}" if client_id and scope_name else ""
+
+    if kind != "managed_upload":
+        # external_s3 and future kinds are handled by later phases.
+        return None
+    if status != "active":
+        logger.info(
+            "source_registry: skipping source %s (status=%s, scope=%s)",
+            source_id, status, scope_identity,
+        )
+        return None
+    if not scope_identity:
+        logger.warning(
+            "source_registry: skipping source %s — missing client_id/scope_name",
+            source_id,
+        )
+        return None
+
+    storage = row.get("storage_ref") or {}
+    if not isinstance(storage, dict):
+        logger.warning(
+            "source_registry: skipping source %s — storage_ref is not a JSON object",
+            source_id,
+        )
+        return None
+    bucket = storage.get("bucket")
+    prefix = storage.get("prefix")
+    region = storage.get("region")
+    if not bucket or not prefix or not region:
+        logger.warning(
+            "source_registry: skipping source %s scope=%s — storage_ref missing "
+            "one of (bucket=%r, prefix=%r, region=%r)",
+            source_id, scope_identity, bucket, prefix, region,
+        )
+        return None
+
+    return SourceConfig(
+        source_id=source_id,
+        scope_identity=scope_identity,
+        bucket=str(bucket),
+        prefix=str(prefix),
+        region=str(region),
+        qdrant_collection=_qdrant_collection_for_scope(scope_identity),
+    )
+
+
+def load_active_sources() -> list[SourceConfig]:
+    """Return every active `managed_upload` source safe to ingest from.
+
+    An empty list is a valid result — callers are expected to check
+    before constructing the Pathway graph and should apply the
+    env-based synthetic-pilot fallback (see `synthesize_pilot_source`)
+    when appropriate.
+    """
+    if psycopg is None or not _db_url():
+        logger.info(
+            "source_registry: DATABASE_URL or psycopg unavailable — "
+            "skipping registry read (env-fallback path may still apply)",
+        )
+        return []
+
+    try:
+        with psycopg.connect(_db_url(), row_factory=_dict_row) as conn:
+            rows = conn.execute(
+                """
+                SELECT source_id, client_id, scope_name, kind,
+                       display_name, status, storage_ref
+                  FROM knowledge_sources
+                 WHERE kind = 'managed_upload'
+                   AND status = 'active'
+              ORDER BY client_id ASC, scope_name ASC, created_at ASC
+                """,
+            ).fetchall()
+    except Exception as exc:
+        # A DB outage must not take the runtime down silently. Log and
+        # return empty so the env-fallback path can keep the pilot
+        # alive during a control-plane blip.
+        logger.error("source_registry: DB error — %s", exc)
+        return []
+
+    configs: list[SourceConfig] = []
+    for row in rows:
+        cfg = _row_to_config(row)
+        if cfg is not None:
+            configs.append(cfg)
+    logger.info(
+        "source_registry: loaded %d managed_upload source(s) from knowledge_sources",
+        len(configs),
+    )
+    return configs
+
+
+def synthesize_pilot_source() -> SourceConfig | None:
+    """Build a synthetic `SourceConfig` from the legacy pipeline env vars.
+
+    Used only as a rescue path when the registry returns zero rows but
+    the deployment is still configured with the Phase-0 env contract
+    (`S3_BUCKET_NAME` + `S3_PREFIX` + `S3_REGION` + `SCOPE_IDENTITY`).
+    The synthetic source has `source_id=None` so downstream code can
+    tell it apart — no payload pretends to carry a fake UUID.
+    """
+    bucket = os.getenv("S3_BUCKET_NAME", "")
+    prefix = os.getenv("S3_PREFIX", "")
+    region = os.getenv("S3_REGION", "")
+    # Optional — SCOPE_IDENTITY falls back to QDRANT_COLLECTION only for
+    # pilot compatibility; new deployments must always set a human-readable
+    # scope identity.
+    scope_identity = os.getenv("SCOPE_IDENTITY") or os.getenv("QDRANT_COLLECTION", "")
+    if not (bucket and prefix and region and scope_identity):
+        return None
+    qdrant_collection = (
+        os.getenv("QDRANT_COLLECTION")
+        or _qdrant_collection_for_scope(scope_identity)
+    )
+    logger.warning(
+        "source_registry: falling back to synthetic pilot source from env "
+        "(bucket=%s, prefix=%s, scope=%s). Populate knowledge_sources to "
+        "transition off the env-fallback path.",
+        bucket, prefix, scope_identity,
+    )
+    return SourceConfig(
+        source_id=None,
+        scope_identity=scope_identity,
+        bucket=bucket,
+        prefix=prefix,
+        region=region,
+        qdrant_collection=qdrant_collection,
+    )
+
+
+def resolve_sources() -> list[SourceConfig]:
+    """Public entry point used by `pipeline.py::build_pipeline`.
+
+    Order of preference:
+      1. Active rows from `knowledge_sources` (the product model).
+      2. A single synthetic pilot source from env (legacy compat).
+      3. Empty list — the caller should fail fast, because trying to
+         `pw.run()` with no watchers is a silent no-op in Pathway and
+         would otherwise look like a working-but-idle deployment.
+    """
+    configs = load_active_sources()
+    if configs:
+        return configs
+    synthetic = synthesize_pilot_source()
+    return [synthetic] if synthetic else []
+
+
+def log_source_plan(sources: Iterable[SourceConfig]) -> None:
+    """Emit the per-source plan once at startup.
+
+    Kept as a single INFO log so operators see the entire watcher
+    roster together in the pod log — easier to reason about than one
+    line per source interleaved with Pathway's own startup noise.
+    """
+    lines = []
+    for s in sources:
+        tag = "synthetic-env" if s.is_synthetic else f"source_id={s.source_id}"
+        lines.append(
+            f"  - {tag}  scope={s.scope_identity}  "
+            f"s3://{s.bucket}/{s.prefix}  region={s.region}  "
+            f"→ collection {s.qdrant_collection}"
+        )
+    logger.info(
+        "pipeline: %d watcher(s) planned:\n%s",
+        len(lines), "\n".join(lines) if lines else "  (none)",
+    )

--- a/tests/test_source_registry.py
+++ b/tests/test_source_registry.py
@@ -1,0 +1,241 @@
+"""Phase 3 tests: source registry and pipeline planning.
+
+These tests do NOT import `pathway` or spin up a real Pathway graph —
+they cover the control-plane→runtime boundary: the registry reader, the
+row→SourceConfig projection, and the synthetic-pilot fallback. That's
+the logic we can exercise without a Postgres container, without AWS
+credentials, and without a Pathway worker. Graph construction is left
+to live verification on the cluster.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import os
+import sys
+from unittest.mock import MagicMock, patch
+
+# Make sure `src/` is importable — there's no pyproject.toml pythonpath.
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
+
+from ingest.source_registry import (  # noqa: E402
+    SourceConfig,
+    _qdrant_collection_for_scope,
+    _row_to_config,
+    load_active_sources,
+    resolve_sources,
+    synthesize_pilot_source,
+)
+
+
+# ── Collection derivation ──────────────────────────────────────────────────
+
+
+class TestCollectionDerivation:
+    def test_matches_bot_config_api_derivation(self):
+        # The same SHA-256-prefix algorithm bot-config-api and knowledge-api
+        # use. Lock-step at retrieval time requires byte-identical output.
+        scope = "utop/oddspark"
+        expected = "kb-" + hashlib.sha256(scope.encode("utf-8")).hexdigest()[:16]
+        assert _qdrant_collection_for_scope(scope) == expected
+        # Spot-check the pilot's actual collection name.
+        assert _qdrant_collection_for_scope("utop/oddspark") == "kb-45294aa854667d3b"
+
+    def test_different_scopes_yield_different_collections(self):
+        a = _qdrant_collection_for_scope("acme/docs")
+        b = _qdrant_collection_for_scope("acme/api")
+        assert a != b
+        assert a.startswith("kb-") and b.startswith("kb-")
+
+
+# ── Row → SourceConfig projection ─────────────────────────────────────────
+
+
+def _managed_row(
+    *,
+    source_id: str = "3791ba64-3b3f-493a-a7f8-0f08073bde8d",
+    client_id: str = "utop",
+    scope_name: str = "oddspark",
+    bucket: str = "utop-oddspark-document",
+    prefix: str = "architecture/",
+    region: str = "ap-northeast-1",
+    kind: str = "managed_upload",
+    status: str = "active",
+) -> dict:
+    return {
+        "source_id": source_id,
+        "client_id": client_id,
+        "scope_name": scope_name,
+        "kind": kind,
+        "display_name": "Default managed upload",
+        "status": status,
+        "storage_ref": {"bucket": bucket, "prefix": prefix, "region": region},
+    }
+
+
+class TestRowToConfig:
+    def test_valid_managed_upload_row_projects_cleanly(self):
+        cfg = _row_to_config(_managed_row())
+        assert cfg is not None
+        assert cfg.source_id == "3791ba64-3b3f-493a-a7f8-0f08073bde8d"
+        assert cfg.scope_identity == "utop/oddspark"
+        assert cfg.bucket == "utop-oddspark-document"
+        assert cfg.prefix == "architecture/"
+        assert cfg.region == "ap-northeast-1"
+        assert cfg.qdrant_collection == "kb-45294aa854667d3b"
+        assert cfg.is_synthetic is False
+
+    def test_external_s3_kind_is_skipped_without_error(self):
+        # Phase 4 handles external_s3. Phase 3 must skip it.
+        assert _row_to_config(_managed_row(kind="external_s3")) is None
+
+    def test_non_active_status_is_skipped(self):
+        for status in ("provisioning", "paused", "error", "deprovisioning"):
+            assert _row_to_config(_managed_row(status=status)) is None
+
+    def test_incomplete_storage_ref_skips_with_warning(self, caplog):
+        with caplog.at_level("WARNING"):
+            row = _managed_row()
+            row["storage_ref"]["bucket"] = None
+            assert _row_to_config(row) is None
+            assert any("skipping source" in r.message for r in caplog.records)
+
+    def test_missing_scope_parts_skip_with_warning(self, caplog):
+        row = _managed_row(client_id="", scope_name="oddspark")
+        with caplog.at_level("WARNING"):
+            assert _row_to_config(row) is None
+
+    def test_non_dict_storage_ref_is_rejected(self):
+        row = _managed_row()
+        row["storage_ref"] = "not-a-dict"  # type: ignore[assignment]
+        assert _row_to_config(row) is None
+
+
+# ── load_active_sources ────────────────────────────────────────────────────
+
+
+class _FakeConn:
+    def __init__(self, rows):
+        self._rows = rows
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *_):
+        return False
+
+    def execute(self, *_a, **_kw):
+        cur = MagicMock()
+        cur.fetchall.return_value = self._rows
+        return cur
+
+
+class TestLoadActiveSources:
+    def test_returns_empty_list_when_database_url_unset(self, monkeypatch):
+        monkeypatch.delenv("DATABASE_URL", raising=False)
+        assert load_active_sources() == []
+
+    def test_projects_rows_from_postgres(self, monkeypatch):
+        monkeypatch.setenv("DATABASE_URL", "postgresql://x")
+        rows = [_managed_row()]
+        with patch("psycopg.connect", return_value=_FakeConn(rows)):
+            cfgs = load_active_sources()
+        assert len(cfgs) == 1
+        assert cfgs[0].source_id == rows[0]["source_id"]
+
+    def test_skips_unsupported_rows(self, monkeypatch):
+        monkeypatch.setenv("DATABASE_URL", "postgresql://x")
+        rows = [
+            _managed_row(),                             # kept
+            _managed_row(kind="external_s3",            # skipped — Phase 4
+                         source_id="bbbb0000-0000-0000-0000-000000000002"),
+            _managed_row(status="paused",               # skipped — not active
+                         source_id="cccc0000-0000-0000-0000-000000000003"),
+        ]
+        with patch("psycopg.connect", return_value=_FakeConn(rows)):
+            cfgs = load_active_sources()
+        # Only the active managed_upload row survives — _row_to_config
+        # already enforces kind + status; test the aggregate filter.
+        assert len(cfgs) == 1
+        assert cfgs[0].source_id == "3791ba64-3b3f-493a-a7f8-0f08073bde8d"
+
+    def test_db_error_returns_empty_not_raises(self, monkeypatch, caplog):
+        monkeypatch.setenv("DATABASE_URL", "postgresql://x")
+        with patch("psycopg.connect", side_effect=Exception("no route to host")), \
+             caplog.at_level("ERROR"):
+            assert load_active_sources() == []
+            assert any("DB error" in r.message for r in caplog.records)
+
+
+# ── synthesize_pilot_source ───────────────────────────────────────────────
+
+
+class TestSyntheticFallback:
+    def test_returns_none_when_env_incomplete(self, monkeypatch):
+        for var in ("S3_BUCKET_NAME", "S3_PREFIX", "S3_REGION",
+                    "SCOPE_IDENTITY", "QDRANT_COLLECTION"):
+            monkeypatch.delenv(var, raising=False)
+        assert synthesize_pilot_source() is None
+
+    def test_synthetic_config_has_no_source_id(self, monkeypatch):
+        monkeypatch.setenv("S3_BUCKET_NAME", "utop-oddspark-document")
+        monkeypatch.setenv("S3_PREFIX", "architecture/")
+        monkeypatch.setenv("S3_REGION", "ap-northeast-1")
+        monkeypatch.setenv("SCOPE_IDENTITY", "utop/oddspark")
+        cfg = synthesize_pilot_source()
+        assert cfg is not None
+        assert cfg.source_id is None
+        assert cfg.is_synthetic is True
+        # Collection still derived from the scope identity — so a fallback
+        # pilot lands in the same Qdrant bucket the sources-driven path
+        # would.
+        assert cfg.qdrant_collection == "kb-45294aa854667d3b"
+
+    def test_uses_explicit_qdrant_collection_if_set(self, monkeypatch):
+        monkeypatch.setenv("S3_BUCKET_NAME", "b")
+        monkeypatch.setenv("S3_PREFIX", "p/")
+        monkeypatch.setenv("S3_REGION", "r")
+        monkeypatch.setenv("SCOPE_IDENTITY", "x/y")
+        monkeypatch.setenv("QDRANT_COLLECTION", "kb-custom-pin")
+        cfg = synthesize_pilot_source()
+        assert cfg is not None
+        assert cfg.qdrant_collection == "kb-custom-pin"
+
+
+# ── resolve_sources ────────────────────────────────────────────────────────
+
+
+class TestResolveSources:
+    def test_prefers_registry_over_env_fallback(self, monkeypatch):
+        monkeypatch.setenv("DATABASE_URL", "postgresql://x")
+        monkeypatch.setenv("S3_BUCKET_NAME", "b")
+        monkeypatch.setenv("S3_PREFIX", "p/")
+        monkeypatch.setenv("S3_REGION", "r")
+        monkeypatch.setenv("SCOPE_IDENTITY", "x/y")
+        with patch("psycopg.connect", return_value=_FakeConn([_managed_row()])):
+            cfgs = resolve_sources()
+        assert len(cfgs) == 1
+        # Registry row wins — synthetic fallback never materialises.
+        assert cfgs[0].source_id == "3791ba64-3b3f-493a-a7f8-0f08073bde8d"
+        assert cfgs[0].is_synthetic is False
+
+    def test_falls_back_to_synthetic_when_registry_empty(self, monkeypatch):
+        monkeypatch.setenv("DATABASE_URL", "postgresql://x")
+        monkeypatch.setenv("S3_BUCKET_NAME", "utop-oddspark-document")
+        monkeypatch.setenv("S3_PREFIX", "architecture/")
+        monkeypatch.setenv("S3_REGION", "ap-northeast-1")
+        monkeypatch.setenv("SCOPE_IDENTITY", "utop/oddspark")
+        with patch("psycopg.connect", return_value=_FakeConn([])):
+            cfgs = resolve_sources()
+        assert len(cfgs) == 1
+        assert cfgs[0].is_synthetic is True
+        assert cfgs[0].bucket == "utop-oddspark-document"
+
+    def test_empty_when_neither_registry_nor_env_has_data(self, monkeypatch):
+        monkeypatch.delenv("DATABASE_URL", raising=False)
+        for var in ("S3_BUCKET_NAME", "S3_PREFIX", "S3_REGION",
+                    "SCOPE_IDENTITY", "QDRANT_COLLECTION"):
+            monkeypatch.delenv(var, raising=False)
+        assert resolve_sources() == []
+
+


### PR DESCRIPTION
Promotes the Pathway runtime from "one static S3 prefix per deployment" to "watch every active managed_upload row in knowledge_sources", without forcing a corpus reindex and without breaking pilot retrieval.

- New `src/ingest/source_registry.py` reads active `managed_upload` rows from the control-plane table; synthetic fallback from env vars preserves bootstrap + local dev.
- `src/ingest/pipeline.py` loops over resolved sources, building one `pw.io.s3.read → chunk → embed → QdrantSink` subgraph per source.
- `QdrantSink` now writes `source_id` on every new chunk while keeping `document_id = raw S3 key` and `scope` unchanged for read compatibility with the existing corpus.
- 18 unit tests cover the row-to-config projection, DB outage tolerance, synthetic-env fallback, and registry vs env precedence.

Pilot corpus stays retrievable during rollout (no payload shape break for existing chunks; scope filter is unchanged). Depends on the companion infra PR adding DATABASE_URL to the pathway-pipeline deployment.