### PR TITLE
fix(ingest): add psycopg to pipeline image + drop duplicate import

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,6 @@ qdrant-client>=1.7.0
 openai>=1.0.0
 aiohttp>=3.9.0
 python-dotenv>=1.0.0
+# Phase 3 (ADR-001): the ingest runtime reads the `knowledge_sources`
+# control-plane table from Postgres to pick which S3 sources to watch.
+psycopg[binary]>=3.2

--- a/src/ingest/pipeline.py
+++ b/src/ingest/pipeline.py
@@ -69,8 +69,6 @@ from dotenv import load_dotenv  # noqa: E402
 
 from ingest.source_registry import SourceConfig, log_source_plan, resolve_sources  # noqa: E402
 
-from ingest.source_registry import SourceConfig, log_source_plan, resolve_sources
-
 load_dotenv()
 
 logging.basicConfig(


### PR DESCRIPTION
Phase 3 pod fell through to the synthetic-env fallback because psycopg was missing from the Pathway image — the `knowledge_sources` read silently no-op'd. Add it to requirements.txt. Also remove a duplicate import that slipped into pipeline.py.