### PR TITLE
feat(#25): DOCX text extraction — binary dispatch by file extension

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,5 @@ python-dotenv>=1.0.0
 psycopg[binary]>=3.2
 # Issue #19: Prometheus metrics export
 prometheus-client>=0.21
+# Issue #25: DOCX text extraction
+python-docx>=1.0.0

--- a/src/ingest/pipeline.py
+++ b/src/ingest/pipeline.py
@@ -68,6 +68,7 @@ from qdrant_client.models import Distance, PointStruct, VectorParams  # noqa: E4
 from dotenv import load_dotenv  # noqa: E402
 
 from ingest.source_registry import SourceConfig, log_source_plan, resolve_sources  # noqa: E402
+from ingest.text_extract import extract_text as _extract_text_fn  # noqa: E402
 from ingest.vault_creds import CredentialError, read_s3_credentials  # noqa: E402
 from ingest.metrics import (  # noqa: E402
     EVENTS_TOTAL,
@@ -185,6 +186,9 @@ def _chunk_markdown(text: str) -> list:
         chunk["chunk_index"] = i
         chunk["total_chunks"] = total
     return chunks
+
+
+extract_text = pw.udf(_extract_text_fn)
 
 
 @pw.udf
@@ -432,14 +436,14 @@ def _build_source_subgraph(source: SourceConfig) -> None:
             access_key=access_key,
             secret_access_key=secret_key,
         ),
-        format="plaintext_by_object",
+        format="binary",
         mode="streaming",
         with_metadata=True,
         autocommit_duration_ms=POLL_INTERVAL * 1000,
     )
 
     documents = documents.select(
-        text=pw.this.data,
+        text=extract_text(pw.this.data, pw.this._metadata["path"]),
         document_id=pw.this._metadata["path"],
         section_path=pw.this._metadata["path"],
     )

--- a/src/ingest/text_extract.py
+++ b/src/ingest/text_extract.py
@@ -1,0 +1,24 @@
+"""Format-aware text extraction for S3-ingested objects.
+
+Dispatches by file extension so Pathway can read all objects as binary
+and this module handles format-specific parsing. Keeping extraction
+separate from the Pathway graph means it can be tested without pathway.
+
+Supported:
+  .docx — python-docx paragraph extraction
+  all other extensions — UTF-8 decode (replacement chars on bad bytes)
+"""
+
+from __future__ import annotations
+
+import io
+
+
+def extract_text(data: bytes, path: str) -> str:
+    """Return plain text for a binary S3 object, dispatched by extension."""
+    ext = path.rsplit(".", 1)[-1].lower() if "." in path else ""
+    if ext == "docx":
+        import docx  # python-docx
+        doc = docx.Document(io.BytesIO(data))
+        return "\n".join(p.text for p in doc.paragraphs if p.text.strip())
+    return data.decode("utf-8", errors="replace")

--- a/tests/test_docx_ingest.py
+++ b/tests/test_docx_ingest.py
@@ -1,0 +1,95 @@
+"""Issue #25 — DOCX text extraction tests.
+
+These tests cover ingest.text_extract in isolation — no Pathway, no Qdrant,
+no live S3. They verify the format-dispatch logic using in-memory fixtures.
+"""
+
+from __future__ import annotations
+
+import io
+import os
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
+
+from ingest.text_extract import extract_text  # noqa: E402
+
+
+def _make_docx_bytes(paragraphs: list[str]) -> bytes:
+    """Build a minimal DOCX in memory using python-docx."""
+    import docx
+
+    doc = docx.Document()
+    for para in paragraphs:
+        doc.add_paragraph(para)
+    buf = io.BytesIO()
+    doc.save(buf)
+    return buf.getvalue()
+
+
+class TestDocxExtraction:
+    def test_single_paragraph(self):
+        data = _make_docx_bytes(["Hello world"])
+        result = extract_text(data, "docs/sample.docx")
+        assert "Hello world" in result
+
+    def test_multiple_paragraphs_joined(self):
+        data = _make_docx_bytes(["First paragraph", "Second paragraph"])
+        result = extract_text(data, "folder/doc.docx")
+        assert "First paragraph" in result
+        assert "Second paragraph" in result
+
+    def test_empty_paragraphs_skipped(self):
+        data = _make_docx_bytes(["Real content", "", "More content"])
+        result = extract_text(data, "file.docx")
+        assert "Real content" in result
+        assert "More content" in result
+        # empty string paragraphs should not produce blank lines in output
+        assert "\n\n" not in result
+
+    def test_binary_garbage_not_passed_through(self):
+        data = _make_docx_bytes(["Architecture decision: use Pathway"])
+        result = extract_text(data, "arch.docx")
+        # result must be valid UTF-8 plain text, not binary garbage
+        assert isinstance(result, str)
+        result.encode("utf-8")  # raises if result is not valid unicode
+
+
+class TestMarkdownExtraction:
+    def test_plain_utf8_passthrough(self):
+        content = "# Header\n\nSome markdown body."
+        data = content.encode("utf-8")
+        result = extract_text(data, "docs/README.md")
+        assert result == content
+
+    def test_txt_extension_passthrough(self):
+        content = "plain text content"
+        data = content.encode("utf-8")
+        result = extract_text(data, "notes.txt")
+        assert result == content
+
+    def test_no_extension_passthrough(self):
+        content = "content without extension"
+        data = content.encode("utf-8")
+        result = extract_text(data, "noextfile")
+        assert result == content
+
+    def test_unknown_extension_passthrough(self):
+        content = "some content"
+        data = content.encode("utf-8")
+        result = extract_text(data, "file.rst")
+        assert result == content
+
+    def test_bad_bytes_replaced_not_raised(self):
+        data = b"valid start \xff\xfe invalid bytes"
+        result = extract_text(data, "file.md")
+        assert isinstance(result, str)
+        assert "valid start" in result
+
+    def test_case_insensitive_extension(self):
+        content = "content"
+        data = content.encode("utf-8")
+        result = extract_text(data, "FILE.MD")
+        assert result == content


### PR DESCRIPTION
## Summary

- Switches `pw.io.s3.read` from `format=\"plaintext_by_object\"` to `format=\"binary\"` so raw object bytes are available before any decoding
- Adds `src/ingest/text_extract.py` — pure-Python extraction function dispatching by file extension: `.docx` → python-docx paragraph extraction, all others → UTF-8 decode
- Wraps the extraction function as a `pw.udf` in `pipeline.py` and applies it in the `documents.select(...)` step
- Adds `python-docx>=1.0.0` to `requirements.txt`
- Adds `tests/test_docx_ingest.py` — 10 fixture-based tests, no Pathway/Qdrant dependencies

## Test plan

- [x] `TestDocxExtraction` — single paragraph, multiple paragraphs, empty paragraphs skipped, no binary garbage output
- [x] `TestMarkdownExtraction` — UTF-8 passthrough, txt/unknown/no-extension passthrough, bad bytes replaced (not raised), case-insensitive extension
- [x] All 10 tests pass locally: `pytest tests/test_docx_ingest.py -v`

Closes #25