### PR TITLE
fix(ingest): catch docx.Document() failure when Pathway delivers corrupted bytes

### DIFF
--- a/src/ingest/text_extract.py
+++ b/src/ingest/text_extract.py
@@ -1,24 +1,46 @@
 """Format-aware text extraction for S3-ingested objects.
 
-Dispatches by file extension so Pathway can read all objects as binary
-and this module handles format-specific parsing. Keeping extraction
-separate from the Pathway graph means it can be tested without pathway.
+Dispatches by file extension. Designed to handle both str and bytes input
+because Pathway's UDF layer delivers data as str (not bytes) when replaying
+from state or when format="binary" is used with the current Pathway version.
 
 Supported:
-  .docx — python-docx paragraph extraction
-  all other extensions — UTF-8 decode (replacement chars on bad bytes)
+  .docx — python-docx paragraph extraction (bytes input only; str is warned)
+  all other extensions — str returned directly, or bytes decoded as UTF-8
 """
 
 from __future__ import annotations
 
 import io
+import logging
+
+_log = logging.getLogger("text_extract")
 
 
-def extract_text(data: bytes, path: str) -> str:
-    """Return plain text for a binary S3 object, dispatched by extension."""
+def extract_text(data, path: str) -> str:
+    """Return plain text for an S3 object, dispatched by file extension.
+
+    Handles both str and bytes safely:
+    - Non-DOCX str: return as-is (Pathway delivered already-decoded content)
+    - Non-DOCX bytes: decode as UTF-8 with replacement chars
+    - DOCX bytes: extract paragraph text via python-docx
+    - DOCX str: log warning, return "" (bytes required; str recovery unproven)
+    """
     ext = path.rsplit(".", 1)[-1].lower() if "." in path else ""
+
     if ext == "docx":
+        if not isinstance(data, bytes):
+            _log.warning(
+                "docx extraction skipped for %s: expected bytes, got %s. "
+                "Pipeline continues with empty content for this object.",
+                path,
+                type(data).__name__,
+            )
+            return ""
         import docx  # python-docx
         doc = docx.Document(io.BytesIO(data))
         return "\n".join(p.text for p in doc.paragraphs if p.text.strip())
+
+    if isinstance(data, str):
+        return data
     return data.decode("utf-8", errors="replace")

--- a/src/ingest/text_extract.py
+++ b/src/ingest/text_extract.py
@@ -7,6 +7,12 @@ from state or when format="binary" is used with the current Pathway version.
 Supported:
   .docx — python-docx paragraph extraction (bytes input only; str is warned)
   all other extensions — str returned directly, or bytes decoded as UTF-8
+
+Note on Pathway UDF boundary behavior (0.30.0): pw.io.s3.read(format="binary")
+delivers bytes to the UDF, but docx.Document() may raise BadZipFile if Pathway's
+bytes representation differs from the original file bytes. The try/except below
+ensures Pathway never sees an unhandled exception and silently falls back to raw
+bytes — which would produce binary garbage downstream. We catch it and return "".
 """
 
 from __future__ import annotations
@@ -25,6 +31,7 @@ def extract_text(data, path: str) -> str:
     - Non-DOCX bytes: decode as UTF-8 with replacement chars
     - DOCX bytes: extract paragraph text via python-docx
     - DOCX str: log warning, return "" (bytes required; str recovery unproven)
+    - DOCX bytes but invalid ZIP: log warning, return "" (Pathway UDF byte coercion)
     """
     ext = path.rsplit(".", 1)[-1].lower() if "." in path else ""
 
@@ -37,9 +44,19 @@ def extract_text(data, path: str) -> str:
                 type(data).__name__,
             )
             return ""
-        import docx  # python-docx
-        doc = docx.Document(io.BytesIO(data))
-        return "\n".join(p.text for p in doc.paragraphs if p.text.strip())
+        try:
+            import docx  # python-docx
+            doc = docx.Document(io.BytesIO(data))
+            return "\n".join(p.text for p in doc.paragraphs if p.text.strip())
+        except Exception as exc:
+            _log.warning(
+                "docx extraction failed for %s: %s (%s). "
+                "Pipeline continues with empty content for this object.",
+                path,
+                type(exc).__name__,
+                exc,
+            )
+            return ""
 
     if isinstance(data, str):
         return data

--- a/tests/test_docx_ingest.py
+++ b/tests/test_docx_ingest.py
@@ -1,12 +1,17 @@
 """Issue #25 — DOCX text extraction tests.
 
-These tests cover ingest.text_extract in isolation — no Pathway, no Qdrant,
-no live S3. They verify the format-dispatch logic using in-memory fixtures.
+Covers ingest.text_extract in isolation — no Pathway, no Qdrant, no live S3.
+
+Includes regression tests for the str-input crash introduced by PR #62:
+Pathway delivers UDF arguments as str (not bytes) when replaying from state
+or when format="binary" is used. The original code called str.decode() which
+raises AttributeError for every file in the watched prefix.
 """
 
 from __future__ import annotations
 
 import io
+import logging
 import os
 import sys
 
@@ -29,67 +34,87 @@ def _make_docx_bytes(paragraphs: list[str]) -> bytes:
     return buf.getvalue()
 
 
-class TestDocxExtraction:
-    def test_single_paragraph(self):
-        data = _make_docx_bytes(["Hello world"])
-        result = extract_text(data, "docs/sample.docx")
-        assert "Hello world" in result
+# ---------------------------------------------------------------------------
+# Regression tests — the exact failure that hit live (PR #62 bug)
+# ---------------------------------------------------------------------------
 
-    def test_multiple_paragraphs_joined(self):
-        data = _make_docx_bytes(["First paragraph", "Second paragraph"])
-        result = extract_text(data, "folder/doc.docx")
-        assert "First paragraph" in result
-        assert "Second paragraph" in result
+class TestStrInputRegression:
+    """Pathway delivers str, not bytes. These are the live-failure scenarios."""
 
-    def test_empty_paragraphs_skipped(self):
-        data = _make_docx_bytes(["Real content", "", "More content"])
-        result = extract_text(data, "file.docx")
-        assert "Real content" in result
-        assert "More content" in result
-        # empty string paragraphs should not produce blank lines in output
-        assert "\n\n" not in result
-
-    def test_binary_garbage_not_passed_through(self):
-        data = _make_docx_bytes(["Architecture decision: use Pathway"])
-        result = extract_text(data, "arch.docx")
-        # result must be valid UTF-8 plain text, not binary garbage
+    def test_markdown_str_does_not_crash(self):
+        # This exact case crashed the live pipeline
+        data = "# Architecture Decision\n\nUse Pathway for streaming ingest."
+        result = extract_text(data, "architecture/decision.md")
         assert isinstance(result, str)
-        result.encode("utf-8")  # raises if result is not valid unicode
+        assert "Architecture Decision" in result
 
+    def test_plaintext_str_does_not_crash(self):
+        data = "plain text content from S3"
+        result = extract_text(data, "docs/notes.txt")
+        assert result == "plain text content from S3"
 
-class TestMarkdownExtraction:
-    def test_plain_utf8_passthrough(self):
-        content = "# Header\n\nSome markdown body."
-        data = content.encode("utf-8")
-        result = extract_text(data, "docs/README.md")
-        assert result == content
-
-    def test_txt_extension_passthrough(self):
-        content = "plain text content"
-        data = content.encode("utf-8")
-        result = extract_text(data, "notes.txt")
-        assert result == content
-
-    def test_no_extension_passthrough(self):
-        content = "content without extension"
-        data = content.encode("utf-8")
+    def test_str_no_extension_does_not_crash(self):
+        data = "content without extension"
         result = extract_text(data, "noextfile")
-        assert result == content
+        assert result == "content without extension"
 
-    def test_unknown_extension_passthrough(self):
-        content = "some content"
-        data = content.encode("utf-8")
-        result = extract_text(data, "file.rst")
-        assert result == content
+    def test_str_unknown_extension_does_not_crash(self):
+        data = "reStructuredText content"
+        result = extract_text(data, "README.rst")
+        assert result == "reStructuredText content"
 
-    def test_bad_bytes_replaced_not_raised(self):
+    def test_str_returned_verbatim_no_transformation(self):
+        # Pathway already decoded the content — return it as-is, no double-decode
+        data = "exact content with unicode: café, naïve, résumé"
+        result = extract_text(data, "docs/unicode.md")
+        assert result == data
+
+    def test_docx_str_does_not_crash_pipeline(self, caplog):
+        # If a DOCX arrives as str (unknown encoding), pipeline must not crash.
+        # Expected: warning logged, empty string returned.
+        with caplog.at_level(logging.WARNING, logger="text_extract"):
+            result = extract_text("not real docx bytes as str", "file.docx")
+        assert result == ""
+        assert "docx extraction skipped" in caplog.text
+        assert "str" in caplog.text
+
+
+# ---------------------------------------------------------------------------
+# Bytes input — existing correct behavior must not regress
+# ---------------------------------------------------------------------------
+
+class TestBytesInput:
+    def test_markdown_bytes_decoded(self):
+        data = "# Header\n\nSome markdown body.".encode("utf-8")
+        result = extract_text(data, "docs/README.md")
+        assert result == "# Header\n\nSome markdown body."
+
+    def test_bytes_bad_encoding_replaced_not_raised(self):
         data = b"valid start \xff\xfe invalid bytes"
         result = extract_text(data, "file.md")
         assert isinstance(result, str)
         assert "valid start" in result
 
+    def test_docx_bytes_extracts_paragraphs(self):
+        data = _make_docx_bytes(["Hello world", "Second paragraph"])
+        result = extract_text(data, "docs/sample.docx")
+        assert "Hello world" in result
+        assert "Second paragraph" in result
+
+    def test_docx_bytes_skips_empty_paragraphs(self):
+        data = _make_docx_bytes(["Real content", "", "More content"])
+        result = extract_text(data, "file.docx")
+        assert "Real content" in result
+        assert "More content" in result
+        assert "\n\n" not in result
+
+    def test_docx_bytes_readable_text_not_binary(self):
+        data = _make_docx_bytes(["Architecture decision: use Pathway"])
+        result = extract_text(data, "arch.docx")
+        assert isinstance(result, str)
+        result.encode("utf-8")  # raises if not valid unicode
+
     def test_case_insensitive_extension(self):
-        content = "content"
-        data = content.encode("utf-8")
+        data = "content".encode("utf-8")
         result = extract_text(data, "FILE.MD")
-        assert result == content
+        assert result == "content"

--- a/tests/test_docx_ingest.py
+++ b/tests/test_docx_ingest.py
@@ -118,3 +118,11 @@ class TestBytesInput:
         data = "content".encode("utf-8")
         result = extract_text(data, "FILE.MD")
         assert result == "content"
+
+    def test_docx_invalid_bytes_returns_empty_with_warning(self, caplog):
+        # Pathway UDF may deliver bytes that fail docx.Document() — must not crash.
+        # Expected: warning logged, empty string returned.
+        with caplog.at_level(logging.WARNING, logger="text_extract"):
+            result = extract_text(b"not a real docx just raw bytes", "archive.docx")
+        assert result == ""
+        assert "docx extraction failed" in caplog.text


### PR DESCRIPTION
## Summary

- `text_extract.py`: wraps `docx.Document(io.BytesIO(data))` in `try/except` — any failure returns `""` with a WARNING log instead of propagating to Pathway's UDF runner
- `test_docx_ingest.py`: adds `test_docx_invalid_bytes_returns_empty_with_warning` regression test

## Root cause (discovered during hotfix round)

Pathway 0.30.0 `pw.io.s3.read(format="binary")` delivers bytes to the UDF. Those bytes fail `docx.Document()` with `BadZipFile` — Pathway's UDF byte representation differs from the raw S3 file bytes. Without a try/except, Pathway catches the unhandled exception **silently** and substitutes the raw bytes as the column return value. The `chunk_text` UDF then receives bytes, `_chunk_markdown` calls `.decode("utf-8", errors="replace")` on them, and binary garbage (5 chunks of raw DOCX ZIP content) lands in Qdrant.

## Test plan
- [x] 13/13 unit tests pass (`test_docx_ingest.py`)
- [x] New test: `test_docx_invalid_bytes_returns_empty_with_warning` covers the Pathway-specific failure path
- [ ] After merge: deploy, delete v1/v2/v3 garbage DOCX chunks from Qdrant, re-upload DOCX, verify Qdrant shows 0 chunks (empty) instead of 5 binary chunks

## Note: DOCX extraction limitation

With PR #63 + this PR, the pipeline is crash-safe for DOCX files. However, actual DOCX text is NOT yet extractable through the live Pathway pipeline — both paths (str and bytes at UDF boundary) return `""`. DOCX files are silently skipped (empty content, no crash). Full DOCX support requires a Pathway version where `format="binary"` delivers verifiable bytes, or a pre-processing step outside the UDF boundary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)