### PR TITLE
fix(ingest): revert to plaintext_by_object — prevent DOCX binary garbage in Qdrant

### DIFF
--- a/src/ingest/pipeline.py
+++ b/src/ingest/pipeline.py
@@ -200,7 +200,7 @@ def chunk_text(text: str) -> list:
             text = d if isinstance(d, str) else s
         except (json.JSONDecodeError, ValueError):
             text = str(text)
-    return _chunk_markdown(text)
+    return [c for c in _chunk_markdown(text) if c.get("text", "").strip()]
 
 
 # ---------------------------------------------------------------------------
@@ -436,7 +436,7 @@ def _build_source_subgraph(source: SourceConfig) -> None:
             access_key=access_key,
             secret_access_key=secret_key,
         ),
-        format="binary",
+        format="plaintext_by_object",
         mode="streaming",
         with_metadata=True,
         autocommit_duration_ms=POLL_INTERVAL * 1000,


### PR DESCRIPTION
## Root cause

Pathway 0.30.0 silently ignores the return value of `pw.udf` functions when the input column has `bytes` type. `format="binary"` creates a `bytes`-type column, so even though `extract_text()` correctly returned `""` for DOCX files (after PR #64), Pathway kept passing raw bytes downstream to `_chunk_markdown`. The fallback `bytes.decode("utf-8", errors="replace")` in `_chunk_markdown` then decoded the raw DOCX ZIP bytes into UTF-8 garbage, producing 5 binary chunks per DOCX file in Qdrant.

## Fix

- **`format="binary"` → `format="plaintext_by_object"`** — the `data` column is now `str` type, where Pathway honours UDF return values correctly. DOCX `str` input hits the existing guard in `extract_text()` → returns `""` → zero Qdrant chunks.
- **Empty-chunk filter in `chunk_text` UDF** — `return [c for c in _chunk_markdown(text) if c.get("text", "").strip()]` ensures any `extract_text()` empty return produces zero Qdrant points instead of one garbage point.

## What this does NOT fix

DOCX text is still not extractable through the Pathway 0.30.0 UDF layer for `str` input (real binary can't be decoded from a str). This is a Pathway limitation — DOCX requires `bytes` to pass to `docx.Document()`, but Pathway only delivers `str` via `plaintext_by_object`. A proper DOCX pipeline requires either: (a) Pathway upgrade, or (b) pre-processing outside the UDF boundary. Tracking as a follow-up.

## Verification plan

1. CI passes
2. ArgoCD deploys new image
3. Upload fresh DOCX to S3 prefix → confirm **0 new Qdrant chunks** (no garbage)
4. Delete existing garbage DOCX chunks (v2/v3/v4 smoke objects) from Qdrant manually
5. Confirm existing `.md` / `.txt` files continue to chunk correctly

Fixes #25 (partial: crash fixed, binary garbage prevented)