### PR TITLE
fix(r1): pre-download NLTK + user home for unstructured

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,10 +13,24 @@ RUN apt-get update \
 COPY requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
 
+# Pre-download NLTK resources required by unstructured's text tokenizer.
+# Without this, `unstructured.partition.text` tries to download at first
+# call via `nltk.download(..., download_dir=<user home>)`, which fails
+# under our non-root user (no writable home). Pin the shared download
+# dir and set NLTK_DATA so every process finds them.
+ENV NLTK_DATA=/opt/nltk_data
+RUN mkdir -p /opt/nltk_data && \
+    python -c "import nltk; \
+               nltk.download('averaged_perceptron_tagger_eng', download_dir='/opt/nltk_data', quiet=True); \
+               nltk.download('punkt_tab', download_dir='/opt/nltk_data', quiet=True)" && \
+    chmod -R a+rX /opt/nltk_data
+
 COPY src/ src/
 
-RUN useradd --no-create-home --uid 1000 pathway && \
-    chown -R pathway:pathway /app
+# Give the pathway user a writable home — some parser deps still look
+# at $HOME for caches even when XDG / project-scoped dirs would work.
+RUN useradd --create-home --home-dir /home/pathway --uid 1000 pathway && \
+    chown -R pathway:pathway /app /home/pathway
 USER pathway
 
 CMD ["python", "src/ingest/pipeline.py"]

--- a/src/ingest/pipeline.py
+++ b/src/ingest/pipeline.py
@@ -220,6 +220,28 @@ def _is_pdf(path_meta) -> bool:
 
 
 @pw.udf
+def _as_bytes(data) -> bytes:
+    """Guarantee bytes at the parser boundary.
+
+    `pw.io.s3.read(format="binary")` is documented to produce a `data: bytes`
+    column (`parse_utf8=False` internally). On dev we observed the column
+    arriving as `str` at the Pathway UDF boundary — the parser crashes
+    with `TypeError: a bytes-like object is required, not 'str'` inside
+    `BytesIO(contents)`.
+
+    This guard coerces to bytes. `latin-1` is used for str→bytes because
+    it is a lossless 1:1 mapping of every byte 0..255; if Pathway's
+    Rust engine preserved the raw byte values through a str handle
+    (no UTF-8 decode), latin-1 encode recovers them exactly.
+    """
+    if isinstance(data, bytes):
+        return data
+    if isinstance(data, str):
+        return data.encode("latin-1", errors="replace")
+    return bytes(data)
+
+
+@pw.udf
 def _element_text(element) -> str:
     """Extract the text field from a (text, metadata) parser output tuple.
 
@@ -503,12 +525,12 @@ def _build_source_subgraph(source: SourceConfig) -> None:
     other_docs = classified.filter(~classified._is_pdf)
 
     pdf_parsed = pdf_docs.select(
-        elements=_pdf_parser(pw.this.data),
+        elements=_pdf_parser(_as_bytes(pw.this.data)),
         document_id=pw.this._metadata["path"],
         section_path=pw.this._metadata["path"],
     )
     other_parsed = other_docs.select(
-        elements=_unstructured_parser(pw.this.data),
+        elements=_unstructured_parser(_as_bytes(pw.this.data)),
         document_id=pw.this._metadata["path"],
         section_path=pw.this._metadata["path"],
     )


### PR DESCRIPTION
Unblock dev. Unstructured's tokenizer needs NLTK data + writable $HOME.