### PR TITLE
fix(r1-forensic): add libgl1 for cv2 on raw binary parsing

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,8 +7,15 @@ WORKDIR /app
 #   unstructured.partition.auto). Missing this raises
 #   FileFormatOrDependencyError at parse time.
 RUN apt-get update \
-    && apt-get install -y --no-install-recommends libmagic1 \
+    && apt-get install -y --no-install-recommends \
+        libmagic1 \
+        libgl1 \
+        libglib2.0-0 \
     && rm -rf /var/lib/apt/lists/*
+# libgl1 + libglib2.0-0: required at import time by cv2 (pulled in by
+# unstructured_inference, which unstructured.partition.auto imports
+# eagerly). Without them, any partition call on a binary doc raises
+# `ImportError: libGL.so.1: cannot open shared object file`.
 
 COPY requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt

--- a/src/ingest/pipeline.py
+++ b/src/ingest/pipeline.py
@@ -220,28 +220,6 @@ def _is_pdf(path_meta) -> bool:
 
 
 @pw.udf
-def _as_bytes(data) -> bytes:
-    """Guarantee bytes at the parser boundary.
-
-    `pw.io.s3.read(format="binary")` is documented to produce a `data: bytes`
-    column (`parse_utf8=False` internally). On dev we observed the column
-    arriving as `str` at the Pathway UDF boundary — the parser crashes
-    with `TypeError: a bytes-like object is required, not 'str'` inside
-    `BytesIO(contents)`.
-
-    This guard coerces to bytes. `latin-1` is used for str→bytes because
-    it is a lossless 1:1 mapping of every byte 0..255; if Pathway's
-    Rust engine preserved the raw byte values through a str handle
-    (no UTF-8 decode), latin-1 encode recovers them exactly.
-    """
-    if isinstance(data, bytes):
-        return data
-    if isinstance(data, str):
-        return data.encode("latin-1", errors="replace")
-    return bytes(data)
-
-
-@pw.udf
 def _element_text(element) -> str:
     """Extract the text field from a (text, metadata) parser output tuple.
 
@@ -505,7 +483,7 @@ def _build_source_subgraph(source: SourceConfig) -> None:
             access_key=access_key,
             secret_access_key=secret_key,
         ),
-        format="plaintext_by_object",
+        format="binary",
         mode="streaming",
         with_metadata=True,
         autocommit_duration_ms=POLL_INTERVAL * 1000,
@@ -525,12 +503,12 @@ def _build_source_subgraph(source: SourceConfig) -> None:
     other_docs = classified.filter(~classified._is_pdf)
 
     pdf_parsed = pdf_docs.select(
-        elements=_pdf_parser(_as_bytes(pw.this.data)),
+        elements=_pdf_parser(pw.this.data),
         document_id=pw.this._metadata["path"],
         section_path=pw.this._metadata["path"],
     )
     other_parsed = other_docs.select(
-        elements=_unstructured_parser(_as_bytes(pw.this.data)),
+        elements=_unstructured_parser(pw.this.data),
         document_id=pw.this._metadata["path"],
         section_path=pw.this._metadata["path"],
     )


### PR DESCRIPTION
UnstructuredParser's auto-partition module eagerly imports cv2 via unstructured_inference. cv2 needs libGL.so.1 at load time. Not surfaced previously because normalized uploads never hit the binary-partition path.